### PR TITLE
Fix Gemma4 broken streaming text in Anthropic Messages API

### DIFF
--- a/tests/test_starts_thinking_detection.py
+++ b/tests/test_starts_thinking_detection.py
@@ -102,5 +102,42 @@ class TestDetectStartsThinking(unittest.TestCase):
         self.assertFalse(result)
 
 
+class TestStartsThinkingIntegration(unittest.TestCase):
+    """Verify the old inline code path is replaced."""
+
+    def test_gemma4_closed_block_produces_text_not_thinking(self):
+        """End-to-end: when starts_thinking is False, plain text routes as text."""
+        from vllm_mlx.api.utils import StreamingThinkRouter
+
+        # Simulate Gemma4 with _starts_thinking=False (the fix)
+        router = StreamingThinkRouter(
+            start_in_thinking=False,
+            start_token="<|channel>",
+            end_tokens=["<channel|>", "<|channel>response"],
+            channel_strip_prefix="thought\n",
+        )
+        pieces = router.process("Paris") + router.flush()
+
+        # Should be text, not thinking
+        self.assertEqual(len(pieces), 1)
+        self.assertEqual(pieces[0], ("text", "Paris"))
+
+    def test_gemma4_true_starts_thinking_strips_and_misclassifies(self):
+        """Demonstrates the bug: starts_thinking=True eats short responses."""
+        from vllm_mlx.api.utils import StreamingThinkRouter
+
+        # The old broken behavior
+        router = StreamingThinkRouter(
+            start_in_thinking=True,
+            start_token="<|channel>",
+            end_tokens=["<channel|>", "<|channel>response"],
+            channel_strip_prefix="thought\n",
+        )
+        pieces = router.process("Paris") + router.flush()
+
+        # "Paris" (5 chars) is entirely consumed by the 8-char strip counter
+        self.assertEqual(pieces, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_starts_thinking_detection.py
+++ b/tests/test_starts_thinking_detection.py
@@ -1,0 +1,106 @@
+"""Tests for _detect_starts_thinking helper."""
+
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestDetectStartsThinking(unittest.TestCase):
+    """Test the render-and-inspect approach for _starts_thinking."""
+
+    def _make_tokenizer(self, rendered_suffix: str):
+        """Create a mock tokenizer whose apply_chat_template returns a prompt ending with rendered_suffix."""
+        tok = MagicMock()
+        tok.chat_template = "template with <|channel> and add_generation_prompt"
+        tok.apply_chat_template = MagicMock(
+            return_value=f"<bos><|turn>user\nx<turn|>\n<|turn>model\n{rendered_suffix}"
+        )
+        return tok
+
+    def test_closed_thinking_block_returns_false(self):
+        """Gemma4 without enable_thinking: <|channel>thought\\n<channel|> is CLOSED."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = self._make_tokenizer("<|channel>thought\n<channel|>")
+        result = _detect_starts_thinking(
+            tok, start_token="<|channel>", end_tokens=["<channel|>", "<|channel>response"]
+        )
+        self.assertFalse(result)
+
+    def test_open_thinking_block_returns_true(self):
+        """Qwen3-style: template injects <think> with no </think> -> open."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = self._make_tokenizer("<think>")
+        tok.chat_template = "template with <think> and add_generation_prompt"
+        result = _detect_starts_thinking(
+            tok, start_token="<think>", end_tokens=["</think>"]
+        )
+        self.assertTrue(result)
+
+    def test_no_start_token_in_template_returns_false(self):
+        """Template doesn't contain start token at all -> False."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = self._make_tokenizer("")
+        tok.chat_template = "template with add_generation_prompt but no channel token"
+        result = _detect_starts_thinking(
+            tok, start_token="<|channel>", end_tokens=["<channel|>"]
+        )
+        self.assertFalse(result)
+
+    def test_no_add_generation_prompt_in_template_returns_false(self):
+        """Template doesn't contain add_generation_prompt -> False."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = self._make_tokenizer("<|channel>")
+        tok.chat_template = "template with <|channel> but no gen prompt"
+        result = _detect_starts_thinking(
+            tok, start_token="<|channel>", end_tokens=["<channel|>"]
+        )
+        self.assertFalse(result)
+
+    def test_no_tokenizer_returns_false(self):
+        """No tokenizer available -> False."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        result = _detect_starts_thinking(
+            None, start_token="<think>", end_tokens=["</think>"]
+        )
+        self.assertFalse(result)
+
+    def test_tokenizer_without_chat_template_returns_false(self):
+        """Tokenizer exists but has no chat_template attr -> False."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = MagicMock(spec=[])
+        result = _detect_starts_thinking(
+            tok, start_token="<think>", end_tokens=["</think>"]
+        )
+        self.assertFalse(result)
+
+    def test_template_render_exception_falls_back_to_naive_check(self):
+        """If apply_chat_template raises, fall back to naive text check (True)."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = MagicMock()
+        tok.chat_template = "template with <think> and add_generation_prompt"
+        tok.apply_chat_template = MagicMock(side_effect=Exception("template error"))
+        result = _detect_starts_thinking(
+            tok, start_token="<think>", end_tokens=["</think>"]
+        )
+        self.assertTrue(result)
+
+    def test_multiple_end_tokens_checks_all(self):
+        """With multiple end tokens, any closing after start -> False."""
+        from vllm_mlx.server import _detect_starts_thinking
+
+        tok = self._make_tokenizer("<|channel>thought\n<|channel>response\nsome text")
+        tok.chat_template = "has <|channel> and add_generation_prompt"
+        result = _detect_starts_thinking(
+            tok, start_token="<|channel>", end_tokens=["<channel|>", "<|channel>response"]
+        )
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1939,16 +1939,8 @@ async def _stream_anthropic_messages(
         _channel_strip = None
         _parser_label = "none"
 
-    # Detect if the model's chat template injects the start token into the
-    # generation prompt. If so, the model starts in thinking mode and the
-    # opening tag never appears in the output stream.
     _tokenizer = engine.tokenizer if hasattr(engine, "tokenizer") else None
-    _chat_template = ""
-    if _tokenizer and hasattr(_tokenizer, "chat_template"):
-        _chat_template = _tokenizer.chat_template or ""
-    _starts_thinking = (
-        _start_token in _chat_template and "add_generation_prompt" in _chat_template
-    )
+    _starts_thinking = _detect_starts_thinking(_tokenizer, _start_token, _end_tokens)
 
     logger.info(
         "StreamingThinkRouter: parser=%s start=%r end=%r strip=%r start_in_thinking=%r",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1776,6 +1776,13 @@ def _detect_starts_thinking(
     if start_token not in chat_template or "add_generation_prompt" not in chat_template:
         return False
 
+    # NOTE: enable_thinking is deliberately NOT passed here. The probe must
+    # match the kwargs the BatchedEngine uses (batched.py:387-392), which
+    # also omits enable_thinking. Templates that default it to True (Qwen3)
+    # produce the correct open-thinking result; templates that default it to
+    # False (Gemma4) produce the correct closed-thinking result. If a future
+    # engine path passes enable_thinking explicitly, this probe must be
+    # updated to match.
     try:
         rendered = tokenizer.apply_chat_template(
             [{"role": "user", "content": "x"}],

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1752,6 +1752,52 @@ async def count_anthropic_tokens(request: Request):
     return {"input_tokens": total_tokens}
 
 
+def _detect_starts_thinking(
+    tokenizer,
+    start_token: str,
+    end_tokens: list[str],
+) -> bool:
+    """Detect if the model's chat template leaves thinking genuinely OPEN.
+
+    Renders a minimal test prompt and checks whether the start token
+    appears after the last end token in the rendered output. This
+    correctly handles Gemma4 where the template contains <|channel> but
+    emits a CLOSED block (<|channel>thought\\n<channel|>) when
+    enable_thinking is not set.
+
+    Falls back to the naive text-in-template check if rendering fails
+    (safe default: True means router starts in thinking mode).
+    """
+    if tokenizer is None:
+        return False
+    if not hasattr(tokenizer, "chat_template"):
+        return False
+    chat_template = tokenizer.chat_template or ""
+    if start_token not in chat_template or "add_generation_prompt" not in chat_template:
+        return False
+
+    try:
+        rendered = tokenizer.apply_chat_template(
+            [{"role": "user", "content": "x"}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+    except Exception:
+        return True
+
+    suffix = rendered[-300:]
+    last_start = suffix.rfind(start_token)
+    if last_start < 0:
+        return False
+
+    # Check from the start token position onward for any end token.
+    # Using last_start (not last_start + len) handles end tokens that
+    # share the start token as a prefix (e.g. <|channel>response).
+    from_start = suffix[last_start:]
+    has_close = any(et in from_start for et in end_tokens)
+    return not has_close
+
+
 def _emit_content_pieces(
     pieces: list[tuple[str, str]],
     current_block_type: str | None,


### PR DESCRIPTION
## Summary

Gemma4 models returned empty or mangled text responses through the Anthropic Messages API because `_starts_thinking` was incorrectly `True` when thinking was not enabled. The naive check just looked for the start token (`<|channel>`) in the chat template text, but Gemma4 templates *contain* that token while emitting a **closed** block (`<|channel>thought\n<channel|>`) when `enable_thinking` is off. This caused `StreamingThinkRouter` to start in thinking mode, where it applied the strip-prefix counter and ate the actual text content.

## Changes

- **`vllm_mlx/server.py`** -- Added `_detect_starts_thinking()` helper that renders a minimal test prompt via `apply_chat_template` and inspects whether the start token remains genuinely open (no matching end token after it). Replaced the inline naive text-in-template check with this helper. Added documentation comment explaining why `enable_thinking` is deliberately omitted from the probe kwargs and the sync requirement with `BatchedEngine`.
- **`tests/test_starts_thinking_detection.py`** -- New test file with 10 tests covering: closed blocks (Gemma4), open blocks (Qwen3), missing start tokens, missing `add_generation_prompt`, null/no-template tokenizers, render exceptions falling back to naive check, multiple end tokens, and two integration tests demonstrating the bug vs. the fix through `StreamingThinkRouter` directly.

## Test Plan

- All 55 tests pass (`python -m pytest tests/`)
- Live verified: Gemma4 text responses now stream correctly
- Live verified: Gemma4 tool use still works
- Live verified: Qwen3.5 thinking + text unaffected

---

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)