### PR TITLE
fix: tolerate mlx_lm 0.31+ API drift (Batch split + next() tuple)

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -176,13 +176,32 @@ def _install_chunked_prefill(
     """
     import time as _time
 
-    from mlx_lm.generate import (
-        Batch,
-        _left_pad_prompts,
-        _make_cache,
-        _merge_caches,
-        _right_pad_prompts,
-    )
+    # mlx_lm 0.31+ split `Batch` into `GenerationBatch` / `PromptProcessingBatch`
+    # with different constructor signatures. Our monkey-patch below was written
+    # against the pre-split API and can't be adapted trivially. When the old
+    # symbol is gone, skip the chunked-prefill install entirely and emit a
+    # loud WARN so operators know: long prompts will go through in a single
+    # prefill pass (fine for most workloads, may OOM on >32k prompts), and the
+    # mid-prefill cache-save hook for memory-aware cache is skipped.
+    try:
+        from mlx_lm.generate import (
+            Batch,
+            _left_pad_prompts,
+            _make_cache,
+            _merge_caches,
+            _right_pad_prompts,
+        )
+    except ImportError as e:
+        logger.warning(
+            "_install_chunked_prefill: mlx_lm.generate no longer exports 'Batch' "
+            "(mlx_lm 0.31+ API drift: %s). Chunked prefill and mid-prefill "
+            "cache save are DISABLED. Long prompts (>prefill_step_size) will "
+            "be processed in a single pass and may hit memory pressure. To "
+            "restore chunked prefill, upgrade vllm_mlx to a version that "
+            "adapts to mlx_lm's new GenerationBatch/PromptProcessingBatch API.",
+            e,
+        )
+        return
 
     # Keep references to originals
     _orig_next = batch_gen._next
@@ -2252,7 +2271,17 @@ class Scheduler:
 
                 # Run generation step if we have running requests
                 if self.batch_generator is not None and self.running:
-                    responses = self.batch_generator.next()
+                    result = self.batch_generator.next()
+                    # mlx_lm 0.31+ returns (prompt_processing_responses,
+                    # generation_responses). Older versions returned a flat
+                    # list of generation responses. Handle both.
+                    if isinstance(result, tuple) and len(result) == 2:
+                        # New API: discard the prompt-processing responses
+                        # (we don't surface those to clients) and keep
+                        # generation responses which carry .uid/.token/etc.
+                        _, responses = result
+                    else:
+                        responses = result
                     output.has_work = True
 
                     if responses:


### PR DESCRIPTION
## Summary

`mlx_lm 0.31.2` introduced two breaking API changes that crashed `BatchedEngine`'s text path:

1. **`Batch` → `GenerationBatch` + `PromptProcessingBatch`** — `_install_chunked_prefill` imported the old symbol and crashed every generation step when memory-aware cache was enabled. Error: `ImportError: cannot import name 'Batch' from 'mlx_lm.generate'`.

2. **`BatchGenerator.next()`** now returns `(prompt_processing_responses, generation_responses)` instead of a flat list. Our scheduler iterated the tuple as if it were a response list, hitting `AttributeError: 'list' object has no attribute 'uid'`.

## What this fixes

- Text-path `BatchedEngine` + `--continuous-batching` + any model now generates tokens again.
- Specifically unblocks live testing of PR #2 (thinking-budget feature) — that PR's happy-path cannot be empirically verified against `mlx_lm 0.31+` without this fix.

## Approach

Surgical, backward-compatible:

- `_install_chunked_prefill` wraps the old imports in `try/except ImportError`. Missing `Batch` → loud WARN + early return (no monkey-patch). Chunked prefill becomes a no-op: long prompts go through in a single prefill pass (fine for most workloads, may hit memory pressure on >32k prompts). Mid-prefill cache-save hook for memory-aware cache is also skipped. Acceptable degradation; server works.

- `Scheduler.step` unpacks the tuple from `BatchGenerator.next()` when it's a 2-tuple, otherwise keeps old flat-list handling. Works on both mlx_lm 0.30.x (flat list) and 0.31+ (tuple).

## Test plan

- **Full test suite**: 1128 passed, 23 pre-existing failures unchanged, zero new regressions.
- **Live smoke**: started `vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching`, POSTed to `/v1/chat/completions`, got 200 + completion tokens. No errors in server log.
- **Backward compat**: the tuple check uses `isinstance(result, tuple) and len(result) == 2`, so old mlx_lm (flat list return) still works.

## Known limitations (follow-up)

Restoring chunked prefill against the new mlx_lm API is a larger refactor — `GenerationBatch` and `PromptProcessingBatch` have very different constructor signatures and the monkey-patch reimplements ~300 lines of mlx_lm internals. That work is tracked for a separate PR once mlx_lm's new batch API stabilizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)