### PR TITLE
test: HTTP matrix for thinking_token_budget across model families

### DIFF
--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -353,3 +353,30 @@ When `x-thinking-budget-applied: false` comes back but you set a budget, check t
 | Streaming response has `x-thinking-budget-applied: true` AND a WARN line | Tokenizer encoded `<think>`/`</think>` at pre-flight but failed at per-request attach | The streaming header is pre-flight (emitted before the engine runs). Trust the WARN log + `thinking_budget_noop_total` counter over the streaming header when they disagree. Non-streaming headers are authoritative. |
 
 Alert on the log rate of `thinking_token_budget=… but processor could not be attached` — a non-zero rate means a configuration problem in production. The in-process counter `vllm_mlx.metrics.thinking_budget_noop_total` also increments for every no-op.
+
+### Validating live servers across models
+
+For ad-hoc checks that a specific model honors the budget, use the matrix runner:
+
+```bash
+# Single model, inline args:
+python scripts/thinking_budget_matrix.py \
+    --url http://127.0.0.1:8099 \
+    --model mlx-community/Qwen3-0.6B-8bit \
+    --name qwen3-0.6b --family supported \
+    --out /tmp/report.md
+
+# Multi-model run from a config (see tests/data/thinking_budget_matrix.example.json):
+python scripts/thinking_budget_matrix.py --config matrix.json --out /tmp/report.md
+```
+
+The runner sweeps budgets (`None, 0, 64, 512, 2048`) against each server, emits a markdown table with per-cell timing/tokens/header, and runs family-appropriate pass/fail evaluation (e.g., "budget=0 reasoning ≤ budget=64 reasoning", "no-op family returns `header=false`"). Exit code is non-zero if any cell had an HTTP error.
+
+The same matrix drives the pytest integration suite — `tests/test_thinking_budget_matrix.py` asserts the invariants automatically. Run via:
+
+```bash
+THINKING_BUDGET_MATRIX=/path/to/matrix.json \
+    pytest tests/test_thinking_budget_matrix.py -m integration -v
+```
+
+Tests are marked `integration` and skipped by default (no running-server dependency at CI collect time).

--- a/scripts/thinking_budget_matrix.py
+++ b/scripts/thinking_budget_matrix.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Manual matrix runner for thinking_token_budget across live servers.
+
+Pairs with tests/test_thinking_budget_matrix.py but prints a human-readable
+markdown report instead of asserting. Useful for:
+    - Ad-hoc "is the stack alive" checks after a deploy
+    - Generating evidence for PR bodies / incident writeups
+    - Spot-checking a new model before adding it to the pytest matrix
+
+Usage:
+    # Config file form (same schema as $THINKING_BUDGET_MATRIX):
+    python scripts/thinking_budget_matrix.py --config matrix.json
+
+    # Inline form for a single model:
+    python scripts/thinking_budget_matrix.py \\
+        --url http://127.0.0.1:8099 \\
+        --model mlx-community/Qwen3-0.6B-8bit \\
+        --name qwen3-0.6b --family supported
+
+    # Write report to disk:
+    python scripts/thinking_budget_matrix.py --config matrix.json \\
+        --out /tmp/thinking-budget-report.md
+
+Exit codes:
+    0 = all cells finished, report written
+    1 = one or more cells failed (HTTP error, timeout) — report still written
+    2 = config error (missing file, bad JSON)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import requests
+
+
+PROMPT_REASONING = (
+    "Solve step by step: what is the sum of all prime numbers less than 50? "
+    "Show your reasoning thoroughly."
+)
+PROMPT_TRIVIAL = "What is 2+2?"
+
+DEFAULT_TIMEOUT = 180
+
+
+@dataclass
+class Cell:
+    model: str
+    family: str
+    budget: int | None
+    prompt_label: str
+    max_tokens: int
+    finish_reason: str | None
+    completion_tokens: int | None
+    reasoning_chars: int
+    content_chars: int
+    header: str | None
+    elapsed_s: float
+    error: str | None = None
+
+
+def _chat(
+    url: str,
+    model: str,
+    budget: int | None,
+    prompt: str,
+    max_tokens: int,
+    message: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> tuple[dict, dict, float]:
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.3,
+    }
+    if budget is not None:
+        body["thinking_token_budget"] = budget
+    if message is not None:
+        body["thinking_budget_message"] = message
+
+    t0 = time.time()
+    resp = requests.post(
+        f"{url}/v1/chat/completions", json=body, timeout=timeout
+    )
+    elapsed = time.time() - t0
+    resp.raise_for_status()
+    return dict(resp.headers), resp.json(), elapsed
+
+
+def _run_cell(
+    spec: dict,
+    budget: int | None,
+    prompt_label: str,
+    prompt: str,
+    max_tokens: int,
+) -> Cell:
+    try:
+        headers, data, elapsed = _chat(
+            spec["url"], spec["model"], budget, prompt, max_tokens
+        )
+    except requests.exceptions.RequestException as exc:
+        return Cell(
+            model=spec["name"],
+            family=spec["family"],
+            budget=budget,
+            prompt_label=prompt_label,
+            max_tokens=max_tokens,
+            finish_reason=None,
+            completion_tokens=None,
+            reasoning_chars=0,
+            content_chars=0,
+            header=None,
+            elapsed_s=0.0,
+            error=str(exc)[:200],
+        )
+
+    choice = (data.get("choices") or [{}])[0]
+    msg = choice.get("message") or {}
+    usage = data.get("usage") or {}
+    reasoning = msg.get("reasoning") or ""
+    content = msg.get("content") or ""
+    return Cell(
+        model=spec["name"],
+        family=spec["family"],
+        budget=budget,
+        prompt_label=prompt_label,
+        max_tokens=max_tokens,
+        finish_reason=choice.get("finish_reason"),
+        completion_tokens=usage.get("completion_tokens"),
+        reasoning_chars=len(reasoning),
+        content_chars=len(content),
+        header=headers.get("x-thinking-budget-applied"),
+        elapsed_s=round(elapsed, 2),
+    )
+
+
+def _load_matrix(args) -> list[dict]:
+    if args.config:
+        try:
+            return json.loads(open(args.config).read())
+        except Exception as exc:
+            print(f"ERROR: {args.config}: {exc}", file=sys.stderr)
+            sys.exit(2)
+    if args.url and args.model:
+        return [
+            {
+                "name": args.name or args.model.split("/")[-1],
+                "url": args.url,
+                "model": args.model,
+                "family": args.family or "supported",
+            }
+        ]
+    print(
+        "ERROR: must provide either --config or (--url AND --model)",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _run_matrix(matrix: list[dict]) -> list[Cell]:
+    cells: list[Cell] = []
+    # For each model, run a budget sweep on the reasoning prompt (main
+    # invariant check) + a budget=0 trivial cell (fast-path sanity).
+    budget_sweep = [None, 0, 64, 512, 2048]
+    for spec in matrix:
+        print(f"\n=== {spec['name']} ({spec['family']}) ===", file=sys.stderr)
+        for b in budget_sweep:
+            cell = _run_cell(
+                spec, b, "reasoning", PROMPT_REASONING, max_tokens=2048
+            )
+            _log_cell(cell)
+            cells.append(cell)
+        trivial = _run_cell(
+            spec, 0, "trivial", PROMPT_TRIVIAL, max_tokens=256
+        )
+        _log_cell(trivial)
+        cells.append(trivial)
+    return cells
+
+
+def _log_cell(c: Cell) -> None:
+    if c.error:
+        print(
+            f"  budget={c.budget!s:>5} {c.prompt_label:<9} ERROR: {c.error}",
+            file=sys.stderr,
+        )
+        return
+    print(
+        f"  budget={c.budget!s:>5} {c.prompt_label:<9} "
+        f"tokens={c.completion_tokens!s:>4} "
+        f"rc={c.reasoning_chars:>5} cc={c.content_chars:>5} "
+        f"header={c.header!s:<5} t={c.elapsed_s}s",
+        file=sys.stderr,
+    )
+
+
+def _make_markdown(cells: list[Cell]) -> str:
+    """Render a markdown report grouped by model."""
+    lines = [
+        "# Thinking-budget matrix results",
+        "",
+        f"_Generated {time.strftime('%Y-%m-%d %H:%M:%S %Z')}_",
+        "",
+        "## Legend",
+        "- `header` column: value of `x-thinking-budget-applied` response header.",
+        "  `true` = processor attached and enforced; `false` = loud no-op; "
+        "`None` = header absent (budget was not set or streaming).",
+        "- `reasoning_chars` / `content_chars`: length of the reasoning and "
+        "content fields in the response (proxies for thinking/final tokens).",
+        "- `elapsed_s`: wall clock for the single HTTP round trip.",
+        "",
+    ]
+    by_model: dict[str, list[Cell]] = {}
+    for c in cells:
+        by_model.setdefault(c.model, []).append(c)
+
+    for name, group in by_model.items():
+        family = group[0].family
+        lines.append(f"## {name} — family=`{family}`")
+        lines.append("")
+        lines.append(
+            "| budget | prompt | finish | tokens | r_chars | c_chars | "
+            "header | elapsed | error |"
+        )
+        lines.append(
+            "|--------|--------|--------|--------|---------|---------|"
+            "--------|---------|-------|"
+        )
+        for c in group:
+            err = c.error or ""
+            if len(err) > 40:
+                err = err[:37] + "..."
+            lines.append(
+                f"| {c.budget!s} | {c.prompt_label} | "
+                f"{c.finish_reason or '-'} | "
+                f"{c.completion_tokens if c.completion_tokens is not None else '-'} | "
+                f"{c.reasoning_chars} | {c.content_chars} | "
+                f"`{c.header}` | {c.elapsed_s}s | {err} |"
+            )
+        lines.append("")
+        lines.extend(_evaluate(name, family, group))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _evaluate(name: str, family: str, group: list[Cell]) -> list[str]:
+    """Emit pass/fail bullets per model based on family-appropriate
+    invariants. Does NOT raise — this is a report, not an assertion."""
+    out: list[str] = ["**Evaluation:**", ""]
+    errors = [c for c in group if c.error]
+    if errors:
+        out.append(
+            f"- ⚠️ {len(errors)}/{len(group)} cells failed with HTTP errors"
+        )
+        return out
+
+    by_budget = {c.budget: c for c in group if c.prompt_label == "reasoning"}
+    trivial = next(
+        (c for c in group if c.prompt_label == "trivial"), None
+    )
+
+    if family == "supported":
+        # Header must be true for every cell where budget is set
+        for b in (0, 64, 512, 2048):
+            cell = by_budget.get(b)
+            if cell and cell.header != "true":
+                out.append(
+                    f"- ❌ budget={b}: header=`{cell.header}` (expected "
+                    f"`true`) — processor attach failed"
+                )
+            elif cell:
+                out.append(f"- ✅ budget={b}: header=`true`")
+        # Unbounded should NOT carry the header
+        r_none = by_budget.get(None)
+        if r_none and r_none.header is not None:
+            out.append(
+                f"- ⚠️ budget=None: header=`{r_none.header}` "
+                "(expected absent)"
+            )
+        # Ordering: r(0) <= r(64) <= r(512), r(None) >> r(0)
+        r0 = by_budget[0].reasoning_chars if 0 in by_budget else None
+        r64 = by_budget[64].reasoning_chars if 64 in by_budget else None
+        r512 = by_budget[512].reasoning_chars if 512 in by_budget else None
+        rN = by_budget[None].reasoning_chars if None in by_budget else None
+        if r0 is not None and r64 is not None and r0 > r64 + 200:
+            out.append(
+                f"- ❌ budget=0 produced MORE reasoning ({r0}) than "
+                f"budget=64 ({r64}) — check force-close"
+            )
+        elif r0 is not None and r64 is not None:
+            out.append(f"- ✅ budget=0 reasoning ≤ budget=64 reasoning")
+        if r64 is not None and r512 is not None and r64 > r512 + 200:
+            out.append(
+                f"- ❌ budget=64 reasoning ({r64}) exceeds budget=512 "
+                f"({r512})"
+            )
+        if rN is not None and r0 is not None and rN <= r0 + 100:
+            out.append(
+                f"- ⚠️ unbounded reasoning ({rN}) not substantially "
+                f"larger than budget=0 ({r0}) — prompt may be trivial"
+            )
+        elif rN is not None and r0 is not None:
+            out.append(
+                f"- ✅ unbounded reasoning ({rN}) >> budget=0 ({r0})"
+            )
+        # Latency: budget=0 should be faster than unbounded
+        if r_none and 0 in by_budget:
+            z = by_budget[0].elapsed_s
+            n = r_none.elapsed_s
+            if z < n * 0.7:
+                out.append(
+                    f"- ✅ budget=0 ({z}s) << unbounded ({n}s)"
+                )
+            else:
+                out.append(
+                    f"- ⚠️ budget=0 ({z}s) not materially faster than "
+                    f"unbounded ({n}s) — MLX warm-up variance likely"
+                )
+        # Trivial budget=0 sanity
+        if trivial:
+            if trivial.content_chars == 0:
+                out.append(
+                    "- ❌ trivial/budget=0: empty content — force-close "
+                    "may have suppressed the answer"
+                )
+            elif trivial.reasoning_chars > 50:
+                out.append(
+                    f"- ⚠️ trivial/budget=0: reasoning was "
+                    f"{trivial.reasoning_chars} chars (expected ~0)"
+                )
+            else:
+                out.append("- ✅ trivial/budget=0: fast, minimal thinking")
+    elif family.startswith("noop"):
+        # All cells with a budget set must report header=false
+        for b in (0, 64, 512, 2048):
+            cell = by_budget.get(b)
+            if cell and cell.header != "false":
+                out.append(
+                    f"- ❌ budget={b}: header=`{cell.header}` (expected "
+                    f"`false` for noop family)"
+                )
+            elif cell:
+                out.append(f"- ✅ budget={b}: header=`false` (noop)")
+        # Generation must still work
+        empties = [
+            c for c in group
+            if not c.error and (c.content_chars + c.reasoning_chars) == 0
+        ]
+        if empties:
+            out.append(
+                f"- ❌ {len(empties)} cells returned empty output — "
+                "no-op must still generate"
+            )
+        else:
+            out.append("- ✅ all cells produced output despite no-op budget")
+    else:
+        out.append(f"- ⚠️ unknown family `{family}` — no evaluation applied")
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Thinking-budget matrix runner (live HTTP).",
+    )
+    p.add_argument("--config", help="Path to matrix JSON")
+    p.add_argument("--url", help="Server base URL (single-model mode)")
+    p.add_argument("--model", help="Model ID (single-model mode)")
+    p.add_argument("--name", help="Display name (single-model mode)")
+    p.add_argument(
+        "--family",
+        choices=["supported", "noop-mllm", "noop-simple", "noop-parser"],
+        default="supported",
+    )
+    p.add_argument("--out", help="Write markdown report to this path")
+    p.add_argument(
+        "--json-out",
+        help="Write raw per-cell results as JSON to this path",
+    )
+    args = p.parse_args()
+
+    matrix = _load_matrix(args)
+    cells = _run_matrix(matrix)
+    report = _make_markdown(cells)
+
+    if args.out:
+        open(args.out, "w").write(report)
+        print(f"\nReport written to {args.out}", file=sys.stderr)
+    else:
+        print(report)
+
+    if args.json_out:
+        raw = [asdict(c) for c in cells]
+        open(args.json_out, "w").write(json.dumps(raw, indent=2))
+        print(f"JSON written to {args.json_out}", file=sys.stderr)
+
+    # Exit nonzero if any cell had an HTTP error.
+    return 1 if any(c.error for c in cells) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/thinking_budget_matrix.example.json
+++ b/tests/data/thinking_budget_matrix.example.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "qwen3-0.6b",
+    "url": "http://127.0.0.1:8099",
+    "model": "mlx-community/Qwen3-0.6B-8bit",
+    "family": "supported",
+    "parser": "qwen3"
+  },
+  {
+    "name": "qwen3-arena",
+    "url": "http://127.0.0.1:8003",
+    "model": "mlx-community/Qwen3.6-35B-A3B-4bit",
+    "family": "noop-simple",
+    "parser": "qwen3"
+  },
+  {
+    "name": "gemma-4-31b",
+    "url": "http://127.0.0.1:8000",
+    "model": "mlx-community/gemma-4-31b-it-4bit",
+    "family": "noop-mllm",
+    "parser": "gemma4"
+  }
+]

--- a/tests/test_thinking_budget_matrix.py
+++ b/tests/test_thinking_budget_matrix.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live-server matrix tests for thinking_token_budget across model families.
+
+These tests hit a running vllm-mlx HTTP server and validate that thinking
+budgets behave correctly across different reasoning-model families
+(Qwen3, DeepSeek-R1, Gemma 4, GPT-OSS, VLM/MLLM).
+
+Why HTTP instead of direct engine:
+    - Tests the full stack: Pydantic validation, chat_template_kwargs
+      precedence, scheduler attach, logits processor, response headers,
+      parser extraction. A bug in any of those layers surfaces here.
+    - Matches production behavior exactly — arena traffic flows through
+      the same path.
+    - Avoids fragile asyncio fixtures; uses plain `requests`.
+
+How to run:
+    Point THINKING_BUDGET_MATRIX at a JSON file describing the servers
+    and models to test, then run pytest with the integration marker:
+
+        export THINKING_BUDGET_MATRIX=/path/to/matrix.json
+        pytest tests/test_thinking_budget_matrix.py -m integration -v
+
+    Example matrix.json:
+        [
+          {"name": "qwen3-0.6b", "url": "http://127.0.0.1:8099",
+           "model": "mlx-community/Qwen3-0.6B-8bit",
+           "family": "supported", "parser": "qwen3"},
+          {"name": "gemma4", "url": "http://127.0.0.1:8000",
+           "model": "mlx-community/gemma-4-31b-it-4bit",
+           "family": "noop-mllm"}
+        ]
+
+    Each entry's `family` controls assertion strictness:
+        supported   — budget enforcement MUST work; ordering invariants apply
+        noop-mllm   — MLLM path; header MUST be false; generation still works
+        noop-simple — SimpleEngine; header MUST be false
+        noop-parser — reasoning parser not configured or unsupported delimiter
+
+Gated by default: tests are marked `integration` and are skipped unless the
+matrix env var is set AND pytest is invoked with `-m integration`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import requests
+
+
+pytestmark = pytest.mark.integration
+
+
+# Two prompts chosen to exercise different paths:
+#   PROMPT_REASONING: asks for step-by-step work — the model will enter
+#       <think>…</think> and keep thinking until budget or </think>.
+#   PROMPT_TRIVIAL: asks for a simple fact — on budget=0 we expect the
+#       model to answer in one line.
+PROMPT_REASONING = (
+    "Solve step by step: what is the sum of all prime numbers less than 50? "
+    "Show your reasoning thoroughly."
+)
+PROMPT_TRIVIAL = "What is 2+2?"
+
+# Timeouts (seconds) — per cell. Reasoning models can be slow; give each
+# request generous headroom but cap so a stuck server doesn't wedge CI.
+_TIMEOUT_SEC = 120
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """One entry in the test matrix."""
+
+    name: str
+    url: str
+    model: str
+    family: str  # "supported" | "noop-mllm" | "noop-simple" | "noop-parser"
+    parser: str | None = None  # advisory; server decides at startup
+
+
+def _load_matrix() -> list[ModelSpec]:
+    """Load the test matrix from $THINKING_BUDGET_MATRIX, or return []
+    (which causes pytest.mark.parametrize to skip every test with a
+    "empty parameter set" message — same UX as explicit skip)."""
+    path = os.getenv("THINKING_BUDGET_MATRIX")
+    if not path:
+        return []
+    try:
+        data = json.loads(open(path).read())
+    except Exception as exc:
+        pytest.skip(
+            f"matrix file {path!r} unreadable: {exc}",
+            allow_module_level=True,
+        )
+    return [ModelSpec(**entry) for entry in data]
+
+
+def _matrix_ids(spec: ModelSpec) -> str:
+    return f"{spec.name}:{spec.family}"
+
+
+# Load once at module collection. If the env var is unset we fall back
+# to a single sentinel entry that every test skips on — otherwise
+# `pytest.mark.parametrize([])` emits a confusing `[NOTSET]` id.
+_MATRIX = _load_matrix()
+_MATRIX_EMPTY = not _MATRIX
+if _MATRIX_EMPTY:
+    _MATRIX = [ModelSpec(name="unset", url="", model="", family="supported")]
+
+
+def _require_matrix() -> None:
+    if _MATRIX_EMPTY:
+        pytest.skip(
+            "Set THINKING_BUDGET_MATRIX=/path/to/matrix.json to run "
+            "(see module docstring for format)"
+        )
+
+
+@dataclass
+class CellResult:
+    """One (model, budget) measurement."""
+
+    budget: int | None
+    message: str | None
+    finish_reason: str | None
+    completion_tokens: int | None
+    reasoning_chars: int
+    content_chars: int
+    header_applied: str | None  # "true" | "false" | None
+    elapsed_s: float
+    raw_content_starts: str  # first 60 chars (for diagnostics)
+
+
+def _chat(
+    spec: ModelSpec,
+    *,
+    budget: int | None = None,
+    message: str | None = None,
+    prompt: str = PROMPT_REASONING,
+    max_tokens: int = 1024,
+) -> CellResult:
+    """One non-streaming chat-completion round trip."""
+    body: dict[str, Any] = {
+        "model": spec.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.3,
+    }
+    if budget is not None:
+        body["thinking_token_budget"] = budget
+    if message is not None:
+        body["thinking_budget_message"] = message
+
+    t0 = time.time()
+    resp = requests.post(
+        f"{spec.url}/v1/chat/completions",
+        json=body,
+        timeout=_TIMEOUT_SEC,
+    )
+    elapsed = time.time() - t0
+    resp.raise_for_status()
+
+    header = resp.headers.get("x-thinking-budget-applied")
+    data = resp.json()
+    choice = (data.get("choices") or [{}])[0]
+    m = choice.get("message") or {}
+    usage = data.get("usage") or {}
+    reasoning = m.get("reasoning") or ""
+    content = m.get("content") or ""
+
+    return CellResult(
+        budget=budget,
+        message=message,
+        finish_reason=choice.get("finish_reason"),
+        completion_tokens=usage.get("completion_tokens"),
+        reasoning_chars=len(reasoning),
+        content_chars=len(content),
+        header_applied=header,
+        elapsed_s=round(elapsed, 2),
+        raw_content_starts=(content or "")[:60].replace("\n", " "),
+    )
+
+
+# ----- Supported-family invariants -------------------------------------
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+def test_budget_zero_is_fast_and_silent_on_thinking(spec: ModelSpec) -> None:
+    """budget=0: on a reasoning model, thinking MUST be force-closed
+    immediately and the response MUST return rapidly.
+
+    Concrete assertion: reasoning_chars is small (≤ ~50 chars to allow for
+    the forced </think> token arriving after a newline or short prefix);
+    completion_tokens is bounded; and response is much faster than an
+    unbounded run on the same prompt.
+
+    Families:
+        supported  — reasoning stripped to near-empty.
+        noop-*     — no enforcement; we only assert the header is "false".
+    """
+    _require_matrix()
+    r = _chat(spec, budget=0, prompt=PROMPT_TRIVIAL, max_tokens=256)
+
+    if spec.family == "supported":
+        assert r.header_applied == "true", (
+            f"{spec.name}: expected header true, got {r.header_applied!r}. "
+            f"Parser/tokenizer combo may not expose single-token "
+            f"<think>/</think>. Response={r}"
+        )
+        assert r.reasoning_chars <= 50, (
+            f"{spec.name}: budget=0 should produce ~no reasoning, got "
+            f"{r.reasoning_chars} chars"
+        )
+        assert r.content_chars > 0, (
+            f"{spec.name}: budget=0 must still produce an answer; content "
+            f"was empty. reasoning_chars={r.reasoning_chars}"
+        )
+    else:
+        # Loud no-op family: header MUST be false; model generates normally.
+        assert r.header_applied == "false", (
+            f"{spec.name} is family={spec.family}; expected header=false, "
+            f"got {r.header_applied!r}"
+        )
+        # Content or reasoning must come back — generation still runs.
+        assert (r.content_chars + r.reasoning_chars) > 0, (
+            f"{spec.name}: no-op family still has to generate output; "
+            f"got empty response"
+        )
+
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+def test_budget_ordering_invariant(spec: ModelSpec) -> None:
+    """On supported families, higher budgets must permit ≥ thinking.
+
+    We run four budgets (0, 64, 512, None) and assert:
+
+        reasoning(0)  <=  reasoning(64)  <=  reasoning(512)
+        reasoning(0)  <<  reasoning(None)     (strict, on a reasoning prompt)
+
+    We use reasoning *chars* as a robust proxy for thinking tokens — the
+    HTTP response surfaces reasoning in the message.reasoning field after
+    the reasoning parser extracts it. The invariant holds for char counts
+    just as it does for tokens.
+
+    For noop families, we only verify that all four cells return
+    `x-thinking-budget-applied: false` and produce non-empty output.
+    """
+    _require_matrix()
+    cells = [
+        _chat(spec, budget=b, prompt=PROMPT_REASONING, max_tokens=2048)
+        for b in (0, 64, 512, None)
+    ]
+
+    if spec.family == "supported":
+        r0, r64, r512, rnone = (c.reasoning_chars for c in cells)
+        # Monotonicity with slack — tokenization variance can cause small
+        # inversions near the boundary (e.g., 64 vs 80 chars due to a
+        # single multi-char token landing on the edge).
+        slack = 200  # generous; we're asserting qualitative behavior
+        assert r0 <= r64 + slack, (
+            f"{spec.name}: budget=0 produced MORE reasoning ({r0}) than "
+            f"budget=64 ({r64}). Processor mis-attached?"
+        )
+        assert r64 <= r512 + slack, (
+            f"{spec.name}: budget=64 produced MORE reasoning ({r64}) than "
+            f"budget=512 ({r512}). Force-close likely firing late."
+        )
+        # Strict ordering: unbounded MUST be substantially larger than 0.
+        # If this fails, either the prompt didn't provoke reasoning or
+        # the force-close at budget=0 is silently failing.
+        assert rnone > r0 + 100, (
+            f"{spec.name}: unbounded reasoning ({rnone}) not substantially "
+            f"larger than budget=0 ({r0}). Prompt may be too trivial for "
+            f"this model, or budget=0 isn't actually closing."
+        )
+        # Every supported-family cell must carry the header.
+        for c in cells:
+            assert c.header_applied == "true", (
+                f"{spec.name}: budget={c.budget} missing header=true "
+                f"(got {c.header_applied!r})"
+            )
+    else:
+        for c in cells:
+            # None doesn't emit the header at all; 0/64/512 must show false.
+            if c.budget is not None:
+                assert c.header_applied == "false", (
+                    f"{spec.name} ({spec.family}): budget={c.budget} "
+                    f"expected header=false, got {c.header_applied!r}"
+                )
+            # All cells must still generate output.
+            assert c.content_chars + c.reasoning_chars > 0
+
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+def test_budget_zero_is_faster_than_unbounded(spec: ModelSpec) -> None:
+    """budget=0 should return much faster than unbounded on a reasoning
+    prompt, because the force-close cuts generation within a few tokens.
+
+    We allow generous slack (budget=0 < 50% of unbounded) because MLX
+    compile + warm-up variance can dominate on the first call. Sequencing
+    matters: we run budget=0 second so it benefits from the warm cache,
+    biasing AGAINST the test passing — a passing test is a robust signal.
+    """
+    _require_matrix()
+    if spec.family != "supported":
+        pytest.skip(f"{spec.name}: latency assertion only meaningful for "
+                    "supported family")
+
+    # Warm the server with unbounded first, THEN measure budget=0 so the
+    # warm-up cost is absorbed by the unbounded cell.
+    r_none = _chat(spec, budget=None, prompt=PROMPT_REASONING, max_tokens=1024)
+    r_zero = _chat(spec, budget=0, prompt=PROMPT_REASONING, max_tokens=1024)
+
+    assert r_zero.elapsed_s < r_none.elapsed_s * 0.7, (
+        f"{spec.name}: budget=0 ({r_zero.elapsed_s}s) was not materially "
+        f"faster than unbounded ({r_none.elapsed_s}s). Force-close may "
+        f"not be firing, or max_tokens is bounding both cells."
+    )
+
+
+# ----- Graceful wrap-up message ---------------------------------------
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+def test_thinking_budget_message_produces_transition(
+    spec: ModelSpec,
+) -> None:
+    """With a wrap-up message, the forced close should be preceded by the
+    message tokens in the reasoning block. This exercises the
+    message_token_ids path in ThinkingTokenBudgetLogitsProcessor.
+    """
+    _require_matrix()
+    if spec.family != "supported":
+        pytest.skip(f"{spec.name}: message feature only runs on supported "
+                    "family")
+
+    hint = "Wrap up and answer now."
+    # Fetch the raw response so we can inspect the reasoning block text.
+    body = {
+        "model": spec.model,
+        "messages": [{"role": "user", "content": PROMPT_REASONING}],
+        "max_tokens": 2048,
+        "temperature": 0.3,
+        "thinking_token_budget": 64,
+        "thinking_budget_message": hint,
+    }
+    resp = requests.post(
+        f"{spec.url}/v1/chat/completions", json=body, timeout=_TIMEOUT_SEC,
+    )
+    resp.raise_for_status()
+    assert resp.headers.get("x-thinking-budget-applied") == "true"
+    m = (resp.json().get("choices") or [{}])[0].get("message") or {}
+    reasoning = m.get("reasoning") or ""
+    assert reasoning, (
+        f"{spec.name}: message feature — reasoning block was empty; "
+        f"processor may not have attached"
+    )
+    # A distinctive substring from the hint should survive tokenization.
+    # "Wrap up" is the highest-signal phrase; if the tokenizer splits it
+    # weirdly, fall back to checking "answer" which is also in the hint.
+    hit = ("Wrap up" in reasoning) or ("wrap up" in reasoning) or (
+        "answer" in reasoning.lower()
+    )
+    assert hit, (
+        f"{spec.name}: expected wrap-up hint to appear in reasoning "
+        f"block; reasoning was {reasoning[:200]!r}"
+    )
+
+
+# ----- Anthropic /v1/messages plumbing --------------------------------
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+def test_anthropic_messages_path_honors_budget(spec: ModelSpec) -> None:
+    """Same budget=0 invariant via the Anthropic /v1/messages endpoint.
+
+    This catches regressions where the OpenAI adapter is wired but the
+    Anthropic adapter drops the field.
+    """
+    _require_matrix()
+    if spec.family != "supported":
+        pytest.skip(f"{spec.name}: Anthropic plumbing test only on "
+                    "supported family")
+
+    body = {
+        "model": spec.model,
+        "messages": [{"role": "user", "content": PROMPT_TRIVIAL}],
+        "max_tokens": 256,
+        "thinking_token_budget": 0,
+        "temperature": 0.3,
+    }
+    t0 = time.time()
+    resp = requests.post(
+        f"{spec.url}/v1/messages",
+        json=body,
+        timeout=_TIMEOUT_SEC,
+    )
+    elapsed = time.time() - t0
+    resp.raise_for_status()
+
+    assert resp.headers.get("x-thinking-budget-applied") == "true", (
+        f"{spec.name}: Anthropic endpoint dropped the budget — header was "
+        f"{resp.headers.get('x-thinking-budget-applied')!r}. "
+        f"Check AnthropicRequest model + handler plumbing."
+    )
+    data = resp.json()
+    blocks = data.get("content") or []
+    thinking_chars = sum(
+        len(b.get("thinking", "") or "")
+        for b in blocks
+        if b.get("type") == "thinking"
+    )
+    text_chars = sum(
+        len(b.get("text", "") or "")
+        for b in blocks
+        if b.get("type") == "text"
+    )
+    assert thinking_chars <= 50, (
+        f"{spec.name}: budget=0 via Anthropic produced {thinking_chars} "
+        f"thinking chars; expected ~0"
+    )
+    assert text_chars > 0, (
+        f"{spec.name}: Anthropic must still produce an answer at budget=0"
+    )
+    # Soft latency check — Anthropic path shouldn't be dramatically
+    # slower than OpenAI.
+    assert elapsed < _TIMEOUT_SEC * 0.5


### PR DESCRIPTION
## Summary

Adds a gated integration test + CLI runner that validate \`thinking_token_budget\` behavior across multiple reasoning-model families from one matrix config. Answers the user question: *"do different models actually honor the budgets?"* — with automated evidence, not just empirical one-offs.

## What's in it

- **\`tests/test_thinking_budget_matrix.py\`** (5 parametrized tests, \`@integration\`, skipped by default)
  - \`test_budget_zero_is_fast_and_silent_on_thinking\` — reasoning_chars ≤ 50 + non-empty answer on trivial prompt (or \`header=false\` for noop families)
  - \`test_budget_ordering_invariant\` — sweeps budgets (0, 64, 512, None) and asserts monotonicity + strict gap between budget=0 and unbounded
  - \`test_budget_zero_is_faster_than_unbounded\` — runs unbounded first so warm-up favors it; asserts budget=0 wall time < 70% of unbounded
  - \`test_thinking_budget_message_produces_transition\` — wrap-up hint survives tokenization into reasoning block
  - \`test_anthropic_messages_path_honors_budget\` — same budget=0 invariant via \`/v1/messages\`
- **\`scripts/thinking_budget_matrix.py\`** — CLI runner. Sweeps \`None/0/64/512/2048\` per model, emits a markdown report with per-cell timing/tokens/header, family-appropriate pass/fail evaluation, non-zero exit on HTTP failures
- **\`tests/data/thinking_budget_matrix.example.json\`** — example config showing \`supported\`, \`noop-simple\`, \`noop-mllm\` entries
- **\`docs/guides/reasoning.md\`** — pointer to both runners from the Troubleshooting section

## How to run

\`\`\`bash
# Manual markdown report:
python scripts/thinking_budget_matrix.py --config matrix.json --out /tmp/report.md

# Automated pytest invariants:
THINKING_BUDGET_MATRIX=/path/to/matrix.json \\
    pytest tests/test_thinking_budget_matrix.py -m integration -v
\`\`\`

## Test plan

- [x] Collection works when env var unset (clean skips, no \`NOTSET\` noise)
- [x] Collection with \`-m integration\` shows 5 parametrized tests
- [x] CLI help renders correctly
- [x] CLI smoke run against dead port → graceful error report + exit 1
- [x] Existing 156-test suite stays green
- [ ] Live run once servers are up (user will do this post-merge)

## Families supported

| Family | Expected behavior |
|---|---|
| \`supported\` | Budget enforced; \`header=true\`; ordering invariants apply |
| \`noop-mllm\` | MLLM path; \`header=false\`; generation still works |
| \`noop-simple\` | SimpleEngine; \`header=false\` |
| \`noop-parser\` | Parser missing/unsupported; \`header=false\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)