### PR TITLE
fix(thinking-budget): tokens arg is generated-only in mlx_lm 0.31+

### DIFF
--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -127,18 +127,49 @@ class TestProcessorStateMachine:
     def test_prompt_pre_injection_detected(self):
         """Prompt has <think> at end; first output counts as thinking.
 
-        mlx_lm.BatchGenerator passes FULL history (prompt + output). Test
-        inputs below include the prompt [5, 6, 100] followed by the
-        output tokens — matching the production contract.
+        mlx_lm.BatchGenerator passes ONLY GENERATED tokens to the
+        processor (0.31+). The processor uses ``prompt_token_ids`` at
+        construction time to detect implicit-think mode, then counts
+        generated tokens against the budget.
         """
         prompt = [5, 6, 100]  # prompt ends in <think> (id 100)
         p = _make_processor(budget=2, prompt_ids=prompt)
-        # In _init_from_prompt: think_count = 3 - (2+1) = 0 (post-<think> is empty).
-        # Step 1: output=[1] → think_count=1.
-        # Step 2: output=[1, 2] → think_count=2, budget hit, force.
-        _forced_token(p, prompt + [1])            # think_count=1
-        forced = _forced_token(p, prompt + [1, 2])  # think_count=2, force
+        # _init_from_prompt: prompt ends with <think> → _in_think=True,
+        # _think_count = 3 - (2+1) = 0 (no tokens after <think> in prompt).
+        # Step 1: generated=[1] → _think_count=1.
+        # Step 2: generated=[1, 2] → _think_count=2, budget hit, force.
+        _forced_token(p, [1])            # think_count=1
+        forced = _forced_token(p, [1, 2])  # think_count=2, force
         assert forced == 200
+
+    def test_tokens_arg_is_generated_only_not_prompt_plus_output(self):
+        """Regression: mlx_lm.generate.BatchGenerator 0.31+ passes ONLY the
+        generated tokens (TokenBuffer seeded empty), NOT prompt + generated.
+        If the processor slices by ``_prompt_len`` it skips past the actual
+        output and never sees ``<think>``, silently disabling enforcement.
+
+        This test passes generated-only tokens of length less than the
+        (meaningful) prompt_ids length. Under the broken contract, the
+        slice ``token_list[prompt_len:]`` would yield an empty list and
+        budget=0 would never fire. Under the correct contract, ``<think>``
+        at position 0 of generated output triggers the budget check and
+        forces ``</think>`` on the next step.
+        """
+        # prompt_ids carries 5 tokens of context for the processor's
+        # constructor (no <think> at end, so _init_from_prompt stays in
+        # not-thinking state). The state machine in __call__ must ignore
+        # prompt_len when examining the `tokens` arg — which is
+        # generated-only.
+        p = _make_processor(budget=0, prompt_ids=[10, 11, 12, 13, 14])
+        # Generated=[<think>]: state enters thinking, budget=0 hits
+        # immediately, force should fire on THIS call.
+        forced = _forced_token(p, [100])
+        assert forced == 200, (
+            f"budget=0 failed to force </think> after <think> in generated "
+            f"output; got forced={forced}. Likely regression of the "
+            f"prompt_len slicing bug — the processor is examining "
+            f"output[prompt_len:] and never seeing <think> at position 0."
+        )
 
     def test_multi_token_end_sequence(self):
         """End delimiter is multiple tokens — processor forces each in turn."""

--- a/vllm_mlx/logits_processors/thinking_budget.py
+++ b/vllm_mlx/logits_processors/thinking_budget.py
@@ -161,17 +161,21 @@ class ThinkingTokenBudgetLogitsProcessor:
     def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
         """Return modified logits.
 
-        `tokens` is the FULL token history for this request (prompt + output)
-        as an mx.array of ints. We separate prompt from output by the
-        recorded prompt length.
+        `tokens` contract (mlx_lm.generate.BatchGenerator, 0.31+):
+        ``tokens`` is a per-request TokenBuffer view containing ONLY the
+        tokens generated so far (it is seeded empty and grows one token
+        per decode step). It does **not** include the prompt. Accordingly
+        we do not slice by ``_prompt_len`` — the whole buffer is the
+        "output" the state machine needs to scan.
+
+        Note: earlier mlx_lm versions passed prompt + generated here;
+        if you rebase against a version that reverts that behavior, the
+        state machine will mis-count prompt tokens as thinking tokens
+        unless this method is updated in concert.
         """
         # Convert to Python list for the state machine. mlx arrays don't
         # support the slicing/indexing idioms the state machine uses.
-        # mlx_lm.BatchGenerator contract: tokens is the FULL history
-        # (prompt + generated output). We slice by the recorded prompt
-        # length to get the output-only tail.
-        token_list = tokens.tolist()
-        output = token_list[self._prompt_len :]
+        output = tokens.tolist()
 
         self._advance_state(output)
 


### PR DESCRIPTION
## Summary

Root cause fix for a silent enforcement failure empirically observed on a live Qwen3-0.6B server: the thinking-budget header said \`applied: true\` but budgets were never enforced — models thought until natural stop or \`max_tokens\`.

**The bug:** original port assumed mlx_lm's BatchGenerator passes prompt + generated tokens as the \`tokens\` arg to logits processors. In 0.31+ this is not true: each request's \`TokenBuffer\` is seeded empty and grows one token per decode step, so \`tokens\` is generated-only. Our processor's \`output = token_list[self._prompt_len:]\` slicing was therefore skipping past the first \`prompt_len\` GENERATED tokens — including the \`<think>\` at position 0 — leaving the state machine permanently in \`in_think=False\` and the budget check permanently dormant.

**The fix:** drop the \`prompt_len\` slice. The whole \`tokens\` buffer is the output the state machine should scan. \`prompt_token_ids\` stays on the constructor for \`_init_from_prompt\`'s implicit-think detection (prompt pre-injected \`<think>\`), which is independent of the \`__call__\` contract.

## How this was found

Live HTTP trace: instrumented \`__call__\` to log state after every invocation, fired a budget=0 request on a fresh Qwen3-0.6B server, observed:
- 65 processor calls (one per decode step, good)
- \`in_think=False\` every call (bad — should have flipped at step 1)
- \`head=[17, 7521, 6771, 752, 1744]\` at out_len=34 decoded to \`'2?" Let me think'\` — tokens from the MIDDLE of the output, because the first 15 were being sliced off.

## Regression coverage

- \`test_tokens_arg_is_generated_only_not_prompt_plus_output\` — new test pins the fixed contract. Passes prompt_ids=[10,11,12,13,14] (5 tokens, longer than any generated sequence used in the other tests' token inputs) and asserts that \`<think>\` at generated-output position 0 triggers budget=0 force. Under the broken contract this test fails because the slice \`output[5:]\` is empty.
- \`test_prompt_pre_injection_detected\` — updated to pass generated-only tokens (was encoding the old broken assumption).

## Test plan

- [x] \`pytest tests/test_thinking_budget.py tests/test_thinking_budget_rebase_sentinel.py tests/test_reasoning_parser.py\` — **157 passed** (was 156, +1 regression test)
- [x] Live HTTP: traced budget=0 on Qwen3-0.6B shows processor state machine correctly transitions to \`in_think=True\` when \`<think>\` is emitted, then to \`in_end=True\` on the next step, forcing \`</think>\`
- [ ] Full cross-model matrix verification — follow-up (see comments)

## Related

- Surfaces from arena UI report: "thinking OFF thinks MORE than LOW" (budget=0 wasn't enforcing, budget=512 was — but budget=512 enforcement was also not quite right with the old slice; the fix resolves both).
- Parser fix \`55d25cf\` (Quirk #1) was independent and already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)