### PR TITLE
feat(server): warn when thinking_token_budget >= max_tokens

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1525,6 +1525,32 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     if _msg is not None:
         chat_kwargs["thinking_budget_message"] = _msg
 
+    # Sizing guardrail: thinking_token_budget must fit inside max_tokens
+    # with headroom for user-facing content. Without this check, a client
+    # can set budget=8192 + max_tokens=1024 and the model will self-truncate
+    # mid-thinking, producing garbage/cut-off answers that look worse than
+    # no thinking at all. We WARN rather than reject because some clients
+    # legitimately want reasoning-heavy output with minimal content.
+    _MIN_CONTENT_HEADROOM = 256  # reasonable short-answer floor
+    if _budget is not None and _budget > 0 and request.max_tokens is not None:
+        if request.max_tokens <= _budget:
+            logger.warning(
+                "thinking_token_budget=%d >= max_tokens=%d — impossible to "
+                "honor both; thinking will consume the entire generation "
+                "window and content will be truncated or empty. Set "
+                "max_tokens >= thinking_token_budget + %d for content "
+                "headroom.",
+                _budget, request.max_tokens, _MIN_CONTENT_HEADROOM,
+            )
+        elif request.max_tokens - _budget < _MIN_CONTENT_HEADROOM:
+            logger.warning(
+                "thinking_token_budget=%d leaves only %d tokens of content "
+                "headroom under max_tokens=%d. Response content may be "
+                "truncated. Set max_tokens >= %d for safer sizing.",
+                _budget, request.max_tokens - _budget, request.max_tokens,
+                _budget + _MIN_CONTENT_HEADROOM,
+            )
+
     # Was a budget requested by the client? Used to decide whether to emit
     # the x-thinking-budget-applied response header for both streaming and
     # non-streaming paths.


### PR DESCRIPTION
## Summary

Defensive observability for the \"HIGH thinking produces worse output than OFF\" failure mode. If a client sends \`thinking_token_budget=8192\` with \`max_tokens=1024\`, vllm-mlx honors both as stated — the thinking consumes the entire generation window and user-facing content gets truncated or empty. Output looks catastrophically worse than no thinking at all, even though the server is doing exactly what it was told.

This PR adds WARN logs at the chat endpoint when:
1. **\`budget >= max_tokens\`** — impossible to honor both.
2. **\`budget + 256 > max_tokens\`** — content headroom too tight; response will likely truncate.

Operators seeing garbage at high thinking efforts can now grep logs for this WARN and immediately know to bump max_tokens.

WARN rather than reject because a small fraction of clients legitimately want reasoning-heavy output with minimal content (debug tracing, verbose reasoning displays).

## Test plan

- [x] 163 unit tests green (no existing tests exercise logger output; WARN is purely additive)
- [x] Manual: request with budget=8192 max_tokens=1024 produces WARN; request with budget=8192 max_tokens=16384 produces no WARN
- [ ] Live verify on arena servers post-merge

Surfaced during post-merge cross-model validation on Qwen3.6-35B (see \`docs/testing/2026-04-18-answer-quality-vs-budget.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)