### PR TITLE
feat: provider effort/budget unification + cache-clear prefix support

### DIFF
--- a/UPSTREAM_PIN.md
+++ b/UPSTREAM_PIN.md
@@ -130,6 +130,32 @@ silently degrade to raw-text output.
     a WARN on 0.31.2+ — speculative decoding is disabled there until
     the MTP port lands in a follow-up plan.
 
+### Invariant 11: Effort resolver is the single source of truth
+
+Any code path that reads `thinking_token_budget`, `thinking`, `output_config`, or `reasoning_effort` MUST call `vllm_mlx.api.effort.resolve_effort` — either directly (for OpenAI `/v1/chat/completions` endpoint) or via `anthropic_to_openai` (for `/v1/messages` endpoint, which returns a `(ChatCompletionRequest, ResolvedBudget)` tuple).
+
+Adding a new provider dialect means extending `EffortSource` + the resolver. It does NOT mean adding parallel resolution logic in an adapter, the server handler, or the logits processor.
+
+Test guard: `tests/test_effort_resolver.py` + `tests/test_anthropic_adapter_effort.py`.
+
+### Invariant 12: Four-header contract on budget-resolved responses
+
+Every chat-completion or messages response that went through the resolver MUST emit:
+- `x-thinking-budget-applied` (`true` | `false`, absent when no budget requested)
+- `x-thinking-budget-resolved` (int as string, or `"none"`)
+- `x-thinking-budget-source` (one of the `EffortSource` enum values)
+- `x-thinking-budget-max-tokens-floor` (int as string, absent when source=default or budget=0)
+
+Downstream consumer assumption: `hank-llm-arena::proxy.py::_FORWARDED_HEADERS` forwards the `x-thinking-` prefix to clients. Arena's admin UI reads these headers to show a per-request "effort honored" indicator.
+
+Test guard: `tests/test_thinking_budget_headers.py` + matrix rows in `tests/test_thinking_budget_matrix.py`.
+
+### Invariant 13: Non-streaming Anthropic thinking-block ordering
+
+`vllm_mlx.api.anthropic_adapter.openai_to_anthropic` MUST emit a `type: "thinking"` content block BEFORE the `type: "text"` content block when `choice.message.reasoning` is populated. The ordering matches Anthropic's public API and the streaming path (`server.py:1991-2032`).
+
+Test guard: `tests/test_anthropic_adapter_thinking_block.py`.
+
 ## Rebase checklist
 
 When merging upstream changes into this fork:

--- a/docs/guides/effort-and-budget.md
+++ b/docs/guides/effort-and-budget.md
@@ -1,0 +1,116 @@
+# Effort and Thinking Budget
+
+vllm-mlx supports five provider-dialect ways to ask for a reasoning-token budget. All of them normalize to a single internal value (`thinking_token_budget`) via the resolver in `vllm_mlx/api/effort.py`. This page documents every knob, their precedence, and what clients can expect back.
+
+## The knobs
+
+| Where sent | Field | Example |
+|---|---|---|
+| `/v1/chat/completions` + `/v1/messages` | top-level `thinking_token_budget` (int) | `{"thinking_token_budget": 512}` |
+| `/v1/messages` | `thinking.type` + `budget_tokens` | `{"thinking": {"type": "enabled", "budget_tokens": 256}}` |
+| `/v1/messages` | `thinking.type: "disabled"` | `{"thinking": {"type": "disabled"}}` |
+| `/v1/messages` | `thinking.type: "adaptive"` | `{"thinking": {"type": "adaptive"}}` |
+| `/v1/messages` | `output_config.effort` | `{"output_config": {"effort": "high"}}` |
+| `/v1/chat/completions` | `reasoning_effort` | `{"reasoning_effort": "high"}` |
+
+## Effort level → budget
+
+| Effort | budget | max_tokens_floor (hint) |
+|---|---|---|
+| `low` / `minimal` | 512 | 2048 |
+| `medium` / `normal` | 2048 | 4096 |
+| `high` | 8192 | 16384 |
+| `xhigh` | 16384 | 32768 |
+| `max` | min(context_window ÷ 2, 65536) | 2× budget |
+
+`max_tokens_floor` is a **client hint**, returned via the `x-thinking-budget-max-tokens-floor` response header. Clients should ensure `max_tokens >= max_tokens_floor` to avoid mid-thought truncation. The server does not enforce this — it's up to the caller.
+
+## Precedence
+
+The resolver evaluates signals in this order; first match wins:
+
+1. Top-level `thinking_token_budget` (int, including 0)
+2. `thinking.type: "disabled"` → budget = 0
+3. `thinking.type: "enabled"` + `budget_tokens` → budget = `budget_tokens`
+4. `thinking.type: "adaptive"` → budget = None (natural behavior)
+5. `output_config.effort` (table lookup)
+6. `reasoning_effort` (table lookup)
+7. Nothing → budget = None
+
+## Response headers
+
+Every response that went through the resolver emits these headers:
+
+| Header | Values | Meaning |
+|---|---|---|
+| `x-thinking-budget-applied` | `true` / `false` | Whether the logits processor attached AND the model family supports enforcement. Absent when no budget was requested. |
+| `x-thinking-budget-resolved` | int as string, or `"none"` | The resolver's output — what the server actually tried to enforce. |
+| `x-thinking-budget-source` | `top_level` \| `anthropic_thinking_enabled` \| `anthropic_thinking_disabled` \| `anthropic_thinking_adaptive` \| `output_config_effort` \| `reasoning_effort` \| `default` | Which input field won precedence. |
+| `x-thinking-budget-max-tokens-floor` | int as string | Recommended minimum `max_tokens` for this effort level. Absent when source is `default` or budget is 0. |
+| `x-thinking-budget-noop-reason` | string (e.g., `channel_protocol_not_supported`) | Explains why `applied=false`. Only present when applied=false. |
+
+## Per-family enforceability
+
+Not every model family can enforce the budget. The logits processor biases the `</think>` token's logit when the budget is hit — this only works if `</think>` tokenizes to a single token.
+
+| Family | Thinking protocol | Enforceable? |
+|---|---|---|
+| Qwen3 / Qwen3.5 / Qwen3.6 | `<think>…</think>` (single token) | ✓ |
+| DeepSeek-R1 | `<think>…</think>` | ✓ |
+| Generic models with `think_parser` | `<think>…</think>` | ✓ |
+| Gemma 4 | channel protocol (multi-token) | ✗ — loud noop |
+| GPT-OSS / Harmony | channel protocol | ✗ — loud noop |
+
+When a model family cannot enforce, the server attaches the processor anyway (so `applied=false` is a legitimate signal rather than a silent failure), emits `x-thinking-budget-noop-reason`, and generates normally. The request succeeds with no cap applied.
+
+## Examples
+
+### Claude Code's `--effort` flag (Anthropic path)
+
+```bash
+curl -X POST http://localhost:8000/v1/messages \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+    "messages": [{"role": "user", "content": "Think step by step: 13*17"}],
+    "max_tokens": 4000,
+    "output_config": {"effort": "high"}
+  }' -i | head -20
+```
+
+Response headers include:
+```
+x-thinking-budget-applied: true
+x-thinking-budget-resolved: 8192
+x-thinking-budget-source: output_config_effort
+x-thinking-budget-max-tokens-floor: 16384
+```
+
+### OpenAI o1-style `reasoning_effort`
+
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+    "messages": [{"role": "user", "content": "Solve: 13*17"}],
+    "max_tokens": 4000,
+    "reasoning_effort": "medium"
+  }' -i | head -20
+```
+
+### Force no thinking on any path
+
+```json
+{"thinking_token_budget": 0}
+```
+or (Anthropic only)
+```json
+{"thinking": {"type": "disabled"}}
+```
+
+## Sizing rule
+
+When setting a non-zero budget, ensure `max_tokens >= thinking_token_budget + content_headroom` (roughly `budget + 1000` for typical chat responses). If `max_tokens` is too tight, the model hits `max_tokens` while still inside `<think>` and the caller sees `finish_reason: "length"` with an empty or truncated content block.
+
+Clients can trust `x-thinking-budget-max-tokens-floor` as a floor — it is always at least `budget + content_headroom`.

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -2,6 +2,10 @@
 
 vllm-mlx supports reasoning models that show their thinking process before giving an answer. Models like Qwen3 and DeepSeek-R1 wrap their reasoning in `<think>...</think>` tags, and vllm-mlx can parse these tags to separate the reasoning from the final response.
 
+## See also
+
+- **[Effort and thinking budget](./effort-and-budget.md)** — full reference for the `thinking_token_budget` / `reasoning_effort` / `output_config.effort` / `thinking` knobs, their precedence, and per-family enforceability.
+
 ## Why Use Reasoning Parsing?
 
 When a reasoning model generates output, it typically looks like this:

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -268,7 +268,7 @@ class TestAnthropicToOpenai:
 
     def test_simple_request(self):
         req = self._make_request()
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.model == "default"
         assert result.max_tokens == 100
         assert len(result.messages) == 1
@@ -277,7 +277,7 @@ class TestAnthropicToOpenai:
 
     def test_system_string(self):
         req = self._make_request(system="Be helpful.")
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert len(result.messages) == 2
         assert result.messages[0].role == "system"
         assert result.messages[0].content == "Be helpful."
@@ -285,38 +285,38 @@ class TestAnthropicToOpenai:
 
     def test_system_list(self):
         req = self._make_request(system=[{"type": "text", "text": "Be concise."}])
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.messages[0].role == "system"
         assert result.messages[0].content == "Be concise."
 
     def test_temperature_default(self):
         req = self._make_request()
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.temperature == 0.7
 
     def test_temperature_explicit(self):
         req = self._make_request(temperature=0.3)
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.temperature == 0.3
 
     def test_top_p_default(self):
         req = self._make_request()
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.top_p == 0.9
 
     def test_top_p_explicit(self):
         req = self._make_request(top_p=0.5)
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.top_p == 0.5
 
     def test_stop_sequences(self):
         req = self._make_request(stop_sequences=["END", "STOP"])
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.stop == ["END", "STOP"]
 
     def test_stream_flag(self):
         req = self._make_request(stream=True)
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.stream is True
 
     def test_tools_conversion(self):
@@ -332,18 +332,18 @@ class TestAnthropicToOpenai:
                 )
             ]
         )
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert len(result.tools) == 1
         assert result.tools[0].function["name"] == "search"
 
     def test_tool_choice_conversion(self):
         req = self._make_request(tool_choice={"type": "any"})
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.tool_choice == "required"
 
     def test_no_tools(self):
         req = self._make_request()
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert result.tools is None
         assert result.tool_choice is None
 
@@ -354,7 +354,7 @@ class TestAnthropicToOpenai:
             AnthropicMessage(role="user", content="how are you"),
         ]
         req = self._make_request(messages=msgs)
-        result = anthropic_to_openai(req)
+        result, _ = anthropic_to_openai(req)
         assert len(result.messages) == 3
         assert result.messages[0].role == "user"
         assert result.messages[1].role == "assistant"

--- a/tests/test_anthropic_adapter_effort.py
+++ b/tests/test_anthropic_adapter_effort.py
@@ -1,0 +1,76 @@
+"""Integration tests for anthropic_adapter's use of the effort resolver."""
+
+import pytest
+
+from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+from vllm_mlx.api.effort import EffortSource, ResolvedBudget
+
+
+def _mk(body: dict) -> AnthropicRequest:
+    """Build an AnthropicRequest with sensible defaults for testing."""
+    return AnthropicRequest(
+        model="any-model",
+        messages=[],
+        max_tokens=1024,
+        **body,
+    )
+
+
+def test_adapter_returns_tuple_with_resolved_budget():
+    req = _mk({})
+    result = anthropic_to_openai(req, context_window=131072)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    oa_req, resolved = result
+    assert resolved.source == EffortSource.DEFAULT
+
+
+def test_adapter_forwards_top_level_budget():
+    req = _mk({"thinking_token_budget": 777})
+    oa_req, resolved = anthropic_to_openai(req, context_window=131072)
+    assert oa_req.thinking_token_budget == 777
+    assert resolved.budget == 777
+    assert resolved.source == EffortSource.TOP_LEVEL
+
+
+def test_adapter_thinking_disabled_forces_zero():
+    req = _mk({"thinking": {"type": "disabled"}})
+    oa_req, resolved = anthropic_to_openai(req, context_window=131072)
+    assert oa_req.thinking_token_budget == 0
+    assert resolved.source == EffortSource.ANTHROPIC_THINKING_DISABLED
+
+
+def test_adapter_thinking_adaptive_forwards_none():
+    req = _mk({"thinking": {"type": "adaptive"}})
+    oa_req, resolved = anthropic_to_openai(req, context_window=131072)
+    assert oa_req.thinking_token_budget is None
+    assert resolved.source == EffortSource.ANTHROPIC_THINKING_ADAPTIVE
+
+
+def test_adapter_output_config_effort_high():
+    req = _mk({"output_config": {"effort": "high"}})
+    oa_req, resolved = anthropic_to_openai(req, context_window=131072)
+    assert oa_req.thinking_token_budget == 8192
+    assert resolved.source == EffortSource.OUTPUT_CONFIG_EFFORT
+    assert resolved.effort_label == "high"
+
+
+def test_adapter_output_config_effort_max_dynamic():
+    """Context window influences the 'max' budget."""
+    req = _mk({"output_config": {"effort": "max"}})
+    _, small_ctx = anthropic_to_openai(req, context_window=32768)
+    _, large_ctx = anthropic_to_openai(req, context_window=1_000_000)
+    assert small_ctx.budget == 16384
+    assert large_ctx.budget == 65536  # capped
+
+
+def test_adapter_top_level_beats_output_config():
+    """Precedence — top-level thinking_token_budget wins."""
+    req = _mk({
+        "thinking_token_budget": 333,
+        "output_config": {"effort": "max"},
+    })
+    oa_req, resolved = anthropic_to_openai(req, context_window=131072)
+    assert oa_req.thinking_token_budget == 333
+    assert resolved.source == EffortSource.TOP_LEVEL

--- a/tests/test_anthropic_adapter_effort.py
+++ b/tests/test_anthropic_adapter_effort.py
@@ -1,10 +1,8 @@
 """Integration tests for anthropic_adapter's use of the effort resolver."""
 
-import pytest
-
 from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
 from vllm_mlx.api.anthropic_models import AnthropicRequest
-from vllm_mlx.api.effort import EffortSource, ResolvedBudget
+from vllm_mlx.api.effort import EffortSource
 
 
 def _mk(body: dict) -> AnthropicRequest:
@@ -67,10 +65,12 @@ def test_adapter_output_config_effort_max_dynamic():
 
 def test_adapter_top_level_beats_output_config():
     """Precedence — top-level thinking_token_budget wins."""
-    req = _mk({
-        "thinking_token_budget": 333,
-        "output_config": {"effort": "max"},
-    })
+    req = _mk(
+        {
+            "thinking_token_budget": 333,
+            "output_config": {"effort": "max"},
+        }
+    )
     oa_req, resolved = anthropic_to_openai(req, context_window=131072)
     assert oa_req.thinking_token_budget == 333
     assert resolved.source == EffortSource.TOP_LEVEL

--- a/tests/test_anthropic_adapter_thinking_block.py
+++ b/tests/test_anthropic_adapter_thinking_block.py
@@ -1,0 +1,87 @@
+"""Non-streaming /v1/messages response must emit type:'thinking' content
+blocks in addition to type:'text', matching Anthropic's public API and
+the streaming path's behavior."""
+
+from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    Usage,
+)
+
+
+def _mk_openai_response(
+    *,
+    content: str | None = None,
+    reasoning: str | None = None,
+    finish_reason: str = "stop",
+) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="test-id",
+        object="chat.completion",
+        created=0,
+        model="any-model",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=AssistantMessage(
+                    role="assistant",
+                    content=content,
+                    reasoning=reasoning,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=Usage(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+        ),
+    )
+
+
+def test_reasoning_emits_thinking_block_before_text():
+    resp = _mk_openai_response(
+        reasoning="Let me think step by step...",
+        content="The answer is 42.",
+    )
+    out = openai_to_anthropic(resp, model="any-model")
+
+    # Two content blocks, thinking-first.
+    assert len(out.content) == 2
+    assert out.content[0].type == "thinking"
+    assert out.content[0].thinking == "Let me think step by step..."
+    assert out.content[1].type == "text"
+    assert out.content[1].text == "The answer is 42."
+
+
+def test_reasoning_only_no_text():
+    """Pathological model output: reasoning but no final answer. Emit just
+    the thinking block — don't fabricate an empty text block."""
+    resp = _mk_openai_response(reasoning="Still thinking...", content=None)
+    out = openai_to_anthropic(resp, model="any-model")
+
+    assert len(out.content) == 1
+    assert out.content[0].type == "thinking"
+    assert out.content[0].thinking == "Still thinking..."
+
+
+def test_text_only_no_reasoning():
+    """Non-reasoning model path: single text block, unchanged behavior."""
+    resp = _mk_openai_response(content="Hello there.")
+    out = openai_to_anthropic(resp, model="any-model")
+
+    assert len(out.content) == 1
+    assert out.content[0].type == "text"
+    assert out.content[0].text == "Hello there."
+
+
+def test_empty_preserves_placeholder_text_block():
+    """Pre-existing fallback: empty content + no reasoning = empty text block."""
+    resp = _mk_openai_response(content=None, reasoning=None)
+    out = openai_to_anthropic(resp, model="any-model")
+
+    assert len(out.content) == 1
+    assert out.content[0].type == "text"
+    assert out.content[0].text == ""

--- a/tests/test_anthropic_models.py
+++ b/tests/test_anthropic_models.py
@@ -358,3 +358,27 @@ class TestAnthropicResponse:
         assert resp.content[0].type == "text"
         assert resp.content[1].type == "tool_use"
         assert resp.stop_reason == "tool_use"
+
+
+def test_anthropic_request_accepts_output_config():
+    """Claude Code sends output_config; we must not drop it at schema time."""
+    from vllm_mlx.api.anthropic_models import AnthropicRequest
+
+    req = AnthropicRequest(
+        model="any-model",
+        messages=[],
+        max_tokens=1024,
+        output_config={"effort": "high"},
+    )
+    assert req.output_config == {"effort": "high"}
+
+
+def test_anthropic_request_output_config_optional():
+    from vllm_mlx.api.anthropic_models import AnthropicRequest
+
+    req = AnthropicRequest(
+        model="any-model",
+        messages=[],
+        max_tokens=1024,
+    )
+    assert req.output_config is None

--- a/tests/test_bench_compile.py
+++ b/tests/test_bench_compile.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 try:
-    import mlx.core as mx
+    import mlx.core as mx  # noqa: F401 — availability probe
     from mlx_lm import load
 
     HAS_MLX_LM = True

--- a/tests/test_bench_compile.py
+++ b/tests/test_bench_compile.py
@@ -35,9 +35,7 @@ class TestCompileWithRealModel:
         model, tokenizer = model_and_tokenizer
 
         baseline_tokens = []
-        for resp in stream_generate(
-            model, tokenizer, "Hello", max_tokens=5, temp=0.0
-        ):
+        for resp in stream_generate(model, tokenizer, "Hello", max_tokens=5, temp=0.0):
             baseline_tokens.append(resp.token)
             if resp.finish_reason:
                 break
@@ -46,9 +44,7 @@ class TestCompileWithRealModel:
         assert is_compiled(model)
 
         compiled_tokens = []
-        for resp in stream_generate(
-            model, tokenizer, "Hello", max_tokens=5, temp=0.0
-        ):
+        for resp in stream_generate(model, tokenizer, "Hello", max_tokens=5, temp=0.0):
             compiled_tokens.append(resp.token)
             if resp.finish_reason:
                 break

--- a/tests/test_cache_endpoints.py
+++ b/tests/test_cache_endpoints.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cache endpoint integration tests.
+
+Covers GET /v1/cache/stats and DELETE /v1/cache, specifically the
+extension that surfaces / clears the MemoryAwarePrefixCache (held on
+app.state.prefix_cache) alongside the mlx_vlm multimodal tiers.
+"""
+
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+
+def _build_app_with_prefix_cache(prefix_cache):
+    """Attach prefix_cache to app.state.prefix_cache for the endpoint to read."""
+    from vllm_mlx.server import app
+
+    app.state.prefix_cache = prefix_cache
+    return app
+
+
+def test_clear_cache_calls_prefix_cache_clear_when_present():
+    prefix_cache = MagicMock()
+    prefix_cache.clear = MagicMock()
+
+    app = _build_app_with_prefix_cache(prefix_cache)
+    client = TestClient(app)
+
+    resp = client.delete("/v1/cache")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "llm_prefix" in body["caches"]
+    prefix_cache.clear.assert_called_once()
+
+
+def test_clear_cache_skips_prefix_cache_when_absent():
+    """On a server without prefix cache."""
+    from vllm_mlx.server import app
+
+    app.state.prefix_cache = None
+    client = TestClient(app)
+
+    resp = client.delete("/v1/cache")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "llm_prefix" not in body["caches"]
+
+
+def test_cache_stats_includes_prefix_cache_when_present():
+    prefix_cache = MagicMock()
+    prefix_cache.get_stats = MagicMock(
+        return_value={
+            "entries": 42,
+            "memory_bytes": 1_000_000,
+        }
+    )
+
+    app = _build_app_with_prefix_cache(prefix_cache)
+    client = TestClient(app)
+
+    resp = client.get("/v1/cache/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "llm_prefix_cache" in body
+    assert body["llm_prefix_cache"]["entries"] == 42
+
+
+def test_cache_stats_omits_prefix_cache_when_absent():
+    from vllm_mlx.server import app
+
+    app.state.prefix_cache = None
+    client = TestClient(app)
+
+    resp = client.get("/v1/cache/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "llm_prefix_cache" not in body

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -3,7 +3,6 @@
 
 import mlx.core as mx
 import mlx.nn as nn
-import pytest
 
 from vllm_mlx.compile import apply_compile, is_compiled
 

--- a/tests/test_effort_resolver.py
+++ b/tests/test_effort_resolver.py
@@ -181,3 +181,45 @@ def test_output_config_effort_loses_to_thinking_enabled():
     )
     assert result.budget == 222
     assert result.source == EffortSource.ANTHROPIC_THINKING_ENABLED
+
+
+# -----------------------------------------------------------------------------
+# Precedence: OpenAI reasoning_effort
+# -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("effort,expected_budget", [
+    ("low",    512),
+    ("medium", 2048),
+    ("high",   8192),
+])
+def test_reasoning_effort_openai_levels(effort, expected_budget):
+    result = resolve_effort(reasoning_effort=effort)
+    assert result.budget == expected_budget
+    assert result.source == EffortSource.REASONING_EFFORT
+    assert result.effort_label == effort
+
+
+def test_reasoning_effort_accepts_xhigh_via_same_table():
+    """Permissive: OpenAI spec only defines low/medium/high, but we accept
+    xhigh from OpenAI-extension clients via the same table."""
+    result = resolve_effort(reasoning_effort="xhigh")
+    assert result.budget == 16384
+    assert result.source == EffortSource.REASONING_EFFORT
+
+
+def test_reasoning_effort_unknown_falls_through_to_default():
+    result = resolve_effort(reasoning_effort="bogus")
+    assert result.source == EffortSource.DEFAULT
+    assert result.budget is None
+
+
+def test_reasoning_effort_loses_to_output_config():
+    """output_config.effort comes first in precedence (Anthropic-path caller),
+    reasoning_effort is OpenAI-path only — but the resolver doesn't know the
+    path, so precedence decides."""
+    result = resolve_effort(
+        output_config={"effort": "low"},
+        reasoning_effort="high",
+    )
+    assert result.budget == 512
+    assert result.source == EffortSource.OUTPUT_CONFIG_EFFORT

--- a/tests/test_effort_resolver.py
+++ b/tests/test_effort_resolver.py
@@ -1,0 +1,21 @@
+"""Unit tests for vllm_mlx.api.effort — dialect-agnostic budget resolver."""
+
+import pytest
+
+from vllm_mlx.api.effort import (
+    EffortSource,
+    ResolvedBudget,
+    resolve_effort,
+    _EFFORT_TABLE,
+    _MAX_BUDGET_CAP,
+)
+
+
+def test_module_imports_and_exports_public_api():
+    """Scaffold test: the module loads and exposes the documented surface."""
+    assert EffortSource.DEFAULT == "default"
+    assert ResolvedBudget(budget=None, source=EffortSource.DEFAULT,
+                          max_tokens_floor=None, effort_label=None)
+    assert callable(resolve_effort)
+    assert isinstance(_EFFORT_TABLE, dict)
+    assert isinstance(_MAX_BUDGET_CAP, int)

--- a/tests/test_effort_resolver.py
+++ b/tests/test_effort_resolver.py
@@ -19,3 +19,74 @@ def test_module_imports_and_exports_public_api():
     assert callable(resolve_effort)
     assert isinstance(_EFFORT_TABLE, dict)
     assert isinstance(_MAX_BUDGET_CAP, int)
+
+
+# -----------------------------------------------------------------------------
+# Precedence: top-level `thinking_token_budget` (highest)
+# -----------------------------------------------------------------------------
+
+def test_top_level_int_wins_over_everything():
+    """If the caller set thinking_token_budget=N, use N regardless of others."""
+    result = resolve_effort(
+        top_level_budget=1234,
+        anthropic_thinking={"type": "enabled", "budget_tokens": 9999},
+        output_config={"effort": "max"},
+        reasoning_effort="high",
+    )
+    assert result.budget == 1234
+    assert result.source == EffortSource.TOP_LEVEL
+
+
+def test_top_level_zero_is_honored():
+    """0 is a first-class value — force-close thinking at step 1."""
+    result = resolve_effort(top_level_budget=0)
+    assert result.budget == 0
+    assert result.source == EffortSource.TOP_LEVEL
+
+
+# -----------------------------------------------------------------------------
+# Precedence: Anthropic `thinking.type`
+# -----------------------------------------------------------------------------
+
+def test_thinking_disabled_means_budget_zero():
+    result = resolve_effort(anthropic_thinking={"type": "disabled"})
+    assert result.budget == 0
+    assert result.source == EffortSource.ANTHROPIC_THINKING_DISABLED
+
+
+def test_thinking_enabled_with_budget_tokens():
+    result = resolve_effort(
+        anthropic_thinking={"type": "enabled", "budget_tokens": 256}
+    )
+    assert result.budget == 256
+    assert result.source == EffortSource.ANTHROPIC_THINKING_ENABLED
+
+
+def test_thinking_enabled_without_budget_tokens_is_none():
+    """Enabled but no cap = None (natural behavior, same as adaptive)."""
+    result = resolve_effort(anthropic_thinking={"type": "enabled"})
+    assert result.budget is None
+    assert result.source == EffortSource.ANTHROPIC_THINKING_ENABLED
+
+
+def test_thinking_adaptive_is_none_not_warning():
+    """adaptive was previously a WARN-and-ignore case; now it's first-class."""
+    result = resolve_effort(anthropic_thinking={"type": "adaptive"})
+    assert result.budget is None
+    assert result.source == EffortSource.ANTHROPIC_THINKING_ADAPTIVE
+
+
+def test_thinking_unknown_type_falls_through_to_default():
+    """Old behavior only WARNed; new behavior still WARNs but returns DEFAULT
+    so the request doesn't error out."""
+    result = resolve_effort(anthropic_thinking={"type": "bogus"})
+    assert result.budget is None
+    assert result.source == EffortSource.DEFAULT
+
+
+def test_default_when_no_signals():
+    result = resolve_effort()
+    assert result.budget is None
+    assert result.source == EffortSource.DEFAULT
+    assert result.max_tokens_floor is None
+    assert result.effort_label is None

--- a/tests/test_effort_resolver.py
+++ b/tests/test_effort_resolver.py
@@ -90,3 +90,94 @@ def test_default_when_no_signals():
     assert result.source == EffortSource.DEFAULT
     assert result.max_tokens_floor is None
     assert result.effort_label is None
+
+
+# -----------------------------------------------------------------------------
+# Precedence: Anthropic output_config.effort
+# -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("effort,expected_budget,expected_floor", [
+    ("low",    512,   2048),
+    ("medium", 2048,  4096),
+    ("high",   8192,  16384),
+    ("xhigh",  16384, 32768),
+])
+def test_output_config_effort_table_lookup(effort, expected_budget, expected_floor):
+    result = resolve_effort(output_config={"effort": effort})
+    assert result.budget == expected_budget
+    assert result.source == EffortSource.OUTPUT_CONFIG_EFFORT
+    assert result.max_tokens_floor == expected_floor
+    assert result.effort_label == effort
+
+
+def test_output_config_effort_max_with_small_context():
+    """max = min(context_window // 2, _MAX_BUDGET_CAP). 32k ctx → 16k budget."""
+    result = resolve_effort(
+        output_config={"effort": "max"},
+        context_window=32768,
+    )
+    assert result.budget == 16384
+    assert result.max_tokens_floor == 32768
+    assert result.source == EffortSource.OUTPUT_CONFIG_EFFORT
+    assert result.effort_label == "max"
+
+
+def test_output_config_effort_max_capped_at_65k():
+    """max = min(context_window // 2, 65536). 1M ctx → still 65536."""
+    result = resolve_effort(
+        output_config={"effort": "max"},
+        context_window=1_000_000,
+    )
+    assert result.budget == 65536
+    assert result.max_tokens_floor is not None
+    assert result.effort_label == "max"
+
+
+@pytest.mark.parametrize("alias,canonical", [
+    ("minimal", "low"),
+    ("normal",  "medium"),
+])
+def test_output_config_effort_synonyms(alias, canonical):
+    """minimal → low, normal → medium."""
+    result = resolve_effort(output_config={"effort": alias})
+    expected_budget, expected_floor = _EFFORT_TABLE[canonical]
+    assert result.budget == expected_budget
+    assert result.max_tokens_floor == expected_floor
+    assert result.effort_label == alias  # preserve the raw client string
+
+
+def test_output_config_effort_unknown_falls_through_to_default():
+    """Unknown effort string logs WARN, returns DEFAULT — does not error."""
+    result = resolve_effort(output_config={"effort": "absurdly_high"})
+    assert result.budget is None
+    assert result.source == EffortSource.DEFAULT
+
+
+def test_output_config_without_effort_key_is_default():
+    """output_config present but no effort key = default."""
+    result = resolve_effort(output_config={"other": "thing"})
+    assert result.budget is None
+    assert result.source == EffortSource.DEFAULT
+
+
+# -----------------------------------------------------------------------------
+# Precedence: output_config LOSES to higher-precedence signals
+# -----------------------------------------------------------------------------
+
+def test_output_config_effort_loses_to_top_level():
+    result = resolve_effort(
+        top_level_budget=111,
+        output_config={"effort": "max"},
+        context_window=32768,
+    )
+    assert result.budget == 111
+    assert result.source == EffortSource.TOP_LEVEL
+
+
+def test_output_config_effort_loses_to_thinking_enabled():
+    result = resolve_effort(
+        anthropic_thinking={"type": "enabled", "budget_tokens": 222},
+        output_config={"effort": "high"},
+    )
+    assert result.budget == 222
+    assert result.source == EffortSource.ANTHROPIC_THINKING_ENABLED

--- a/tests/test_effort_resolver.py
+++ b/tests/test_effort_resolver.py
@@ -14,8 +14,12 @@ from vllm_mlx.api.effort import (
 def test_module_imports_and_exports_public_api():
     """Scaffold test: the module loads and exposes the documented surface."""
     assert EffortSource.DEFAULT == "default"
-    assert ResolvedBudget(budget=None, source=EffortSource.DEFAULT,
-                          max_tokens_floor=None, effort_label=None)
+    assert ResolvedBudget(
+        budget=None,
+        source=EffortSource.DEFAULT,
+        max_tokens_floor=None,
+        effort_label=None,
+    )
     assert callable(resolve_effort)
     assert isinstance(_EFFORT_TABLE, dict)
     assert isinstance(_MAX_BUDGET_CAP, int)
@@ -24,6 +28,7 @@ def test_module_imports_and_exports_public_api():
 # -----------------------------------------------------------------------------
 # Precedence: top-level `thinking_token_budget` (highest)
 # -----------------------------------------------------------------------------
+
 
 def test_top_level_int_wins_over_everything():
     """If the caller set thinking_token_budget=N, use N regardless of others."""
@@ -47,6 +52,7 @@ def test_top_level_zero_is_honored():
 # -----------------------------------------------------------------------------
 # Precedence: Anthropic `thinking.type`
 # -----------------------------------------------------------------------------
+
 
 def test_thinking_disabled_means_budget_zero():
     result = resolve_effort(anthropic_thinking={"type": "disabled"})
@@ -96,12 +102,16 @@ def test_default_when_no_signals():
 # Precedence: Anthropic output_config.effort
 # -----------------------------------------------------------------------------
 
-@pytest.mark.parametrize("effort,expected_budget,expected_floor", [
-    ("low",    512,   2048),
-    ("medium", 2048,  4096),
-    ("high",   8192,  16384),
-    ("xhigh",  16384, 32768),
-])
+
+@pytest.mark.parametrize(
+    "effort,expected_budget,expected_floor",
+    [
+        ("low", 512, 2048),
+        ("medium", 2048, 4096),
+        ("high", 8192, 16384),
+        ("xhigh", 16384, 32768),
+    ],
+)
 def test_output_config_effort_table_lookup(effort, expected_budget, expected_floor):
     result = resolve_effort(output_config={"effort": effort})
     assert result.budget == expected_budget
@@ -133,10 +143,13 @@ def test_output_config_effort_max_capped_at_65k():
     assert result.effort_label == "max"
 
 
-@pytest.mark.parametrize("alias,canonical", [
-    ("minimal", "low"),
-    ("normal",  "medium"),
-])
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [
+        ("minimal", "low"),
+        ("normal", "medium"),
+    ],
+)
 def test_output_config_effort_synonyms(alias, canonical):
     """minimal → low, normal → medium."""
     result = resolve_effort(output_config={"effort": alias})
@@ -164,6 +177,7 @@ def test_output_config_without_effort_key_is_default():
 # Precedence: output_config LOSES to higher-precedence signals
 # -----------------------------------------------------------------------------
 
+
 def test_output_config_effort_loses_to_top_level():
     result = resolve_effort(
         top_level_budget=111,
@@ -187,11 +201,15 @@ def test_output_config_effort_loses_to_thinking_enabled():
 # Precedence: OpenAI reasoning_effort
 # -----------------------------------------------------------------------------
 
-@pytest.mark.parametrize("effort,expected_budget", [
-    ("low",    512),
-    ("medium", 2048),
-    ("high",   8192),
-])
+
+@pytest.mark.parametrize(
+    "effort,expected_budget",
+    [
+        ("low", 512),
+        ("medium", 2048),
+        ("high", 8192),
+    ],
+)
 def test_reasoning_effort_openai_levels(effort, expected_budget):
     result = resolve_effort(reasoning_effort=effort)
     assert result.budget == expected_budget

--- a/tests/test_gemma4_openai_format.py
+++ b/tests/test_gemma4_openai_format.py
@@ -14,7 +14,6 @@ not just the parser in isolation.
 
 import json
 
-import pytest
 
 from vllm_mlx.api.models import (
     AssistantMessage,

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -3,7 +3,6 @@
 
 import json
 
-import pytest
 
 from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
 

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -210,7 +210,9 @@ class TestGemma4ToolParserStreaming:
 
     def test_streaming_emits_on_close(self):
         """Emits structured tool_calls when end delimiter arrives."""
-        full_text = 'Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        full_text = (
+            'Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        )
         result = self.parser.extract_tool_calls_streaming(
             previous_text='Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}',
             current_text=full_text,

--- a/tests/test_missing_chat_template.py
+++ b/tests/test_missing_chat_template.py
@@ -7,7 +7,6 @@ apply_chat_template() raises ValueError. vllm-mlx should fall back to
 a plain-text prompt format instead of crashing.
 """
 
-import pytest
 
 
 class FakeProcessorNoTemplate:

--- a/tests/test_missing_chat_template.py
+++ b/tests/test_missing_chat_template.py
@@ -8,7 +8,6 @@ a plain-text prompt format instead of crashing.
 """
 
 
-
 class FakeProcessorNoTemplate:
     """Simulates a HuggingFace processor with no chat_template set."""
 
@@ -25,10 +24,14 @@ class FakeProcessorNoTemplate:
 class FakeProcessorWithTemplate:
     """Simulates a working processor for comparison."""
 
-    chat_template = "{% for m in messages %}{{ m['role'] }}: {{ m['content'] }}\n{% endfor %}"
+    chat_template = (
+        "{% for m in messages %}{{ m['role'] }}: {{ m['content'] }}\n{% endfor %}"
+    )
 
     def apply_chat_template(self, messages, **kwargs):
-        return "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
+        return (
+            "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
+        )
 
 
 class TestBatchedEngineChatTemplateFallback:

--- a/tests/test_mllm_scheduler_prompt_tokens.py
+++ b/tests/test_mllm_scheduler_prompt_tokens.py
@@ -11,7 +11,6 @@ fallback when tokenizer.encode raises.
 
 from __future__ import annotations
 
-import logging
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/test_openai_reasoning_effort.py
+++ b/tests/test_openai_reasoning_effort.py
@@ -1,0 +1,34 @@
+"""Schema-level tests for ChatCompletionRequest.reasoning_effort.
+
+Server-side integration (resolver call + thinking_token_budget population)
+is covered by the HTTP matrix test in Task 11.
+"""
+
+import pytest
+
+from vllm_mlx.api.models import ChatCompletionRequest
+
+
+def test_chat_request_accepts_reasoning_effort():
+    req = ChatCompletionRequest(
+        model="any",
+        messages=[],
+        reasoning_effort="high",
+    )
+    assert req.reasoning_effort == "high"
+
+
+def test_chat_request_reasoning_effort_optional():
+    req = ChatCompletionRequest(model="any", messages=[])
+    assert req.reasoning_effort is None
+
+
+def test_chat_request_reasoning_effort_passes_any_string_through():
+    """Validation is intentionally permissive — the resolver handles
+    unknown strings with a WARN + fallthrough to DEFAULT."""
+    req = ChatCompletionRequest(
+        model="any",
+        messages=[],
+        reasoning_effort="some_future_level",
+    )
+    assert req.reasoning_effort == "some_future_level"

--- a/tests/test_openai_reasoning_effort.py
+++ b/tests/test_openai_reasoning_effort.py
@@ -4,8 +4,6 @@ Server-side integration (resolver call + thinking_token_budget population)
 is covered by the HTTP matrix test in Task 11.
 """
 
-import pytest
-
 from vllm_mlx.api.models import ChatCompletionRequest
 
 

--- a/tests/test_streaming_reasoning_tools.py
+++ b/tests/test_streaming_reasoning_tools.py
@@ -1,6 +1,6 @@
 """Test streaming with reasoning parser and tool calls coexisting."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from vllm_mlx.server import _process_streaming_tool_delta, ToolDeltaResult
 
 

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -13,7 +13,9 @@ class TestSamplingParamsThinkingBudget:
         assert sp.thinking_budget_message is None
 
     def test_accepts_values(self):
-        sp = SamplingParams(thinking_token_budget=512, thinking_budget_message="Wrap it up.")
+        sp = SamplingParams(
+            thinking_token_budget=512, thinking_budget_message="Wrap it up."
+        )
         assert sp.thinking_token_budget == 512
         assert sp.thinking_budget_message == "Wrap it up."
 
@@ -104,9 +106,9 @@ class TestProcessorStateMachine:
     def test_enters_think_and_forces_at_budget(self):
         p = _make_processor(budget=3)
         # Emit <think> then 3 thinking tokens — budget hit on the 3rd.
-        _forced_token(p, [100])             # enter think
-        _forced_token(p, [100, 1])          # count=1
-        _forced_token(p, [100, 1, 2])       # count=2
+        _forced_token(p, [100])  # enter think
+        _forced_token(p, [100, 1])  # count=1
+        _forced_token(p, [100, 1, 2])  # count=2
         forced = _forced_token(p, [100, 1, 2, 3])  # count=3, should force
         assert forced == 200
 
@@ -118,9 +120,9 @@ class TestProcessorStateMachine:
     def test_natural_end_no_force(self):
         """Model closes </think> on its own — no force."""
         p = _make_processor(budget=100)
-        _forced_token(p, [100])         # enter
-        _forced_token(p, [100, 1])      # thinking
-        _forced_token(p, [100, 1, 200]) # model closes
+        _forced_token(p, [100])  # enter
+        _forced_token(p, [100, 1])  # thinking
+        _forced_token(p, [100, 1, 200])  # model closes
         # After natural close, subsequent tokens produce no force.
         assert _forced_token(p, [100, 1, 200, 5]) is None
 
@@ -138,7 +140,7 @@ class TestProcessorStateMachine:
         # _think_count = 3 - (2+1) = 0 (no tokens after <think> in prompt).
         # Step 1: generated=[1] → _think_count=1.
         # Step 2: generated=[1, 2] → _think_count=2, budget hit, force.
-        _forced_token(p, [1])            # think_count=1
+        _forced_token(p, [1])  # think_count=1
         forced = _forced_token(p, [1, 2])  # think_count=2, force
         assert forced == 200
 
@@ -206,7 +208,7 @@ class TestProcessorStateMachine:
     def test_multi_token_end_sequence(self):
         """End delimiter is multiple tokens — processor forces each in turn."""
         p = _make_processor(budget=1, end_ids=(200, 201, 202))
-        _forced_token(p, [100])          # enter think, count=0
+        _forced_token(p, [100])  # enter think, count=0
         forced1 = _forced_token(p, [100, 1])  # count=1, hit budget → force 200
         assert forced1 == 200
         forced2 = _forced_token(p, [100, 1, 200])  # force 201
@@ -218,11 +220,9 @@ class TestProcessorStateMachine:
 
     def test_message_injection_prepends_message_tokens(self):
         """thinking_budget_message tokenizes to tokens that force BEFORE end_ids."""
-        p = _make_processor(
-            budget=1, end_ids=(200,), message_ids=[50, 51]
-        )
-        _forced_token(p, [100])              # enter think
-        f1 = _forced_token(p, [100, 1])      # budget hit → first force = first message tok
+        p = _make_processor(budget=1, end_ids=(200,), message_ids=[50, 51])
+        _forced_token(p, [100])  # enter think
+        f1 = _forced_token(p, [100, 1])  # budget hit → first force = first message tok
         assert f1 == 50
         f2 = _forced_token(p, [100, 1, 50])  # second message tok
         assert f2 == 51
@@ -232,6 +232,7 @@ class TestProcessorStateMachine:
 
 class _FakeTokenizer:
     """Minimal tokenizer stand-in that encodes strings to fixed ids."""
+
     _MAP = {
         "<think>": [100],
         "</think>": [200],
@@ -299,14 +300,23 @@ class TestServerResolver:
 
     def test_template_kwargs_only(self):
         assert self._resolve(
-            template_kwargs={"thinking_token_budget": 512, "thinking_budget_message": "wrap"}
+            template_kwargs={
+                "thinking_token_budget": 512,
+                "thinking_budget_message": "wrap",
+            }
         ) == (512, "wrap")
 
     def test_top_level_wins(self):
         assert self._resolve(
             top_level={"b": 1024, "m": None},
-            template_kwargs={"thinking_token_budget": 512, "thinking_budget_message": "wrap"},
-        ) == (1024, "wrap")  # budget from top, message fills from template
+            template_kwargs={
+                "thinking_token_budget": 512,
+                "thinking_budget_message": "wrap",
+            },
+        ) == (
+            1024,
+            "wrap",
+        )  # budget from top, message fills from template
 
     def test_zero_is_a_real_value(self):
         assert self._resolve(top_level={"b": 0, "m": None}) == (0, None)
@@ -357,13 +367,14 @@ class TestApplyPropagation:
     def test_scheduler_output_carries_applied_flag(self):
         """Scheduler's output-producing method must copy
         Request.thinking_budget_applied to the RequestOutput it produces."""
-        from vllm_mlx.request import Request, RequestOutput, SamplingParams
         import inspect
+
         # Read _process_batch_responses source (the method that constructs
         # RequestOutput during the generation step); assert it references
         # thinking_budget_applied so this test breaks if someone deletes the
         # field propagation without replacing it with another mechanism.
         from vllm_mlx.scheduler import Scheduler
+
         source = inspect.getsource(Scheduler._process_batch_responses)
         assert "thinking_budget_applied" in source, (
             "Scheduler._process_batch_responses must reference thinking_budget_applied "
@@ -375,6 +386,7 @@ class TestApplyPropagation:
         on its GenerationOutput (text branch, non-streaming)."""
         import inspect
         from vllm_mlx.engine.batched import BatchedEngine
+
         source = inspect.getsource(BatchedEngine.generate)
         # Verify both the text-branch construction (line ~570) AND the return
         # reference output.thinking_budget_applied.
@@ -386,6 +398,7 @@ class TestApplyPropagation:
     def test_batched_engine_text_stream_constructs_with_applied(self):
         import inspect
         from vllm_mlx.engine.batched import BatchedEngine
+
         source = inspect.getsource(BatchedEngine.stream_generate)
         assert source.count("thinking_budget_applied") >= 2, (
             "BatchedEngine.stream_generate should reference "
@@ -526,7 +539,9 @@ class TestAnthropicPlumbing:
 
         req_no_budget = self._base()
         req_top_level = self._base(thinking_token_budget=512)
-        req_nested_enabled = self._base(thinking={"type": "enabled", "budget_tokens": 256})
+        req_nested_enabled = self._base(
+            thinking={"type": "enabled", "budget_tokens": 256}
+        )
         req_nested_disabled = self._base(thinking={"type": "disabled"})
         req_nested_only_budget = self._base(thinking={"budget_tokens": 256})
 
@@ -555,11 +570,11 @@ class TestMessageTokenCoincidence:
             end_ids=(200,),
             message_ids=[50, 51],
         )
-        _forced_token(p, [100])                # <think>
-        _forced_token(p, [100, 1])             # count=1
-        _forced_token(p, [100, 1, 50])         # count=2, natural 50
-        _forced_token(p, [100, 1, 50, 2])      # count=3
-        _forced_token(p, [100, 1, 50, 2, 3])   # count=4
+        _forced_token(p, [100])  # <think>
+        _forced_token(p, [100, 1])  # count=1
+        _forced_token(p, [100, 1, 50])  # count=2, natural 50
+        _forced_token(p, [100, 1, 50, 2])  # count=3
+        _forced_token(p, [100, 1, 50, 2, 3])  # count=4
         # count=5 hits budget, force sequence begins with token 50
         forced1 = _forced_token(p, [100, 1, 50, 2, 3, 4])
         assert forced1 == 50
@@ -574,9 +589,9 @@ class TestMessageTokenCoincidence:
         while thinking, the processor exits think mode — model closed on
         its own. Subsequent tokens must NOT be forced."""
         p = _make_processor(budget=100, end_ids=(200,))
-        _forced_token(p, [100])              # <think>
-        _forced_token(p, [100, 1])           # count=1
-        _forced_token(p, [100, 1, 200])      # model closed
+        _forced_token(p, [100])  # <think>
+        _forced_token(p, [100, 1])  # count=1
+        _forced_token(p, [100, 1, 200])  # model closed
         # Post-close: no force regardless of counter
         assert _forced_token(p, [100, 1, 200, 5]) is None
         assert _forced_token(p, [100, 1, 200, 5, 6]) is None

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -458,7 +458,7 @@ class TestAnthropicPlumbing:
         from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
 
         req = self._base(thinking_token_budget=512, thinking_budget_message="wrap")
-        openai = anthropic_to_openai(req)
+        openai, _ = anthropic_to_openai(req)
         assert openai.thinking_token_budget == 512
         assert openai.thinking_budget_message == "wrap"
 
@@ -467,8 +467,13 @@ class TestAnthropicPlumbing:
         thinking_token_budget."""
         from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
 
-        req = self._base(thinking={"budget_tokens": 256})
-        openai = anthropic_to_openai(req)
+        # Post-Task 6: the shared effort resolver is strict about
+        # `thinking.type` — it must be one of "enabled"/"disabled"/"adaptive".
+        # Bare {"budget_tokens": N} with no type falls through to DEFAULT.
+        # Anthropic's own API already requires `type` on the thinking dict,
+        # so this matches the upstream contract.
+        req = self._base(thinking={"type": "enabled", "budget_tokens": 256})
+        openai, _ = anthropic_to_openai(req)
         assert openai.thinking_token_budget == 256
 
     def test_adapter_top_level_wins_over_nested(self):
@@ -478,7 +483,7 @@ class TestAnthropicPlumbing:
             thinking_token_budget=1024,
             thinking={"budget_tokens": 256},
         )
-        openai = anthropic_to_openai(req)
+        openai, _ = anthropic_to_openai(req)
         assert openai.thinking_token_budget == 1024
 
     def test_adapter_thinking_disabled_forces_zero(self):
@@ -487,14 +492,14 @@ class TestAnthropicPlumbing:
         from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
 
         req = self._base(thinking={"type": "disabled", "budget_tokens": 1024})
-        openai = anthropic_to_openai(req)
+        openai, _ = anthropic_to_openai(req)
         assert openai.thinking_token_budget == 0  # disabled wins over budget_tokens
 
     def test_adapter_thinking_enabled_uses_budget_tokens(self):
         from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
 
         req = self._base(thinking={"type": "enabled", "budget_tokens": 512})
-        openai = anthropic_to_openai(req)
+        openai, _ = anthropic_to_openai(req)
         assert openai.thinking_token_budget == 512
 
     def test_adapter_unknown_type_ignores(self, caplog):
@@ -506,9 +511,15 @@ class TestAnthropicPlumbing:
 
         req = self._base(thinking={"type": "unknown", "budget_tokens": 256})
         with caplog.at_level(logging.WARNING):
-            openai = anthropic_to_openai(req)
+            openai, _ = anthropic_to_openai(req)
         assert openai.thinking_token_budget is None
-        assert any("not recognized" in rec.message for rec in caplog.records)
+        # Resolver logs "Unknown anthropic_thinking.type=..." and falls through
+        # to DEFAULT (budget None). Match on "Unknown" + "thinking" to stay
+        # tolerant of small log-message wording changes.
+        assert any(
+            "Unknown" in rec.message and "thinking" in rec.message
+            for rec in caplog.records
+        )
 
     def test_anthropic_budget_requested_helper(self):
         from vllm_mlx.server import _anthropic_budget_requested

--- a/tests/test_thinking_budget_headers.py
+++ b/tests/test_thinking_budget_headers.py
@@ -1,0 +1,66 @@
+"""Unit tests for the response-header builder helper."""
+
+from vllm_mlx.api.effort import EffortSource, ResolvedBudget
+
+
+def test_helper_all_fields_on_top_level_budget():
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=512,
+        source=EffortSource.TOP_LEVEL,
+        max_tokens_floor=2048,
+        effort_label=None,
+    )
+    headers = _build_thinking_budget_headers(resolved, applied=True)
+    assert headers["x-thinking-budget-applied"] == "true"
+    assert headers["x-thinking-budget-resolved"] == "512"
+    assert headers["x-thinking-budget-source"] == "top_level"
+    assert headers["x-thinking-budget-max-tokens-floor"] == "2048"
+
+
+def test_helper_default_source_omits_floor():
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=None,
+        source=EffortSource.DEFAULT,
+        max_tokens_floor=None,
+        effort_label=None,
+    )
+    headers = _build_thinking_budget_headers(resolved, applied=None)
+    assert "x-thinking-budget-applied" not in headers  # applied=None → absent
+    assert headers["x-thinking-budget-resolved"] == "none"
+    assert headers["x-thinking-budget-source"] == "default"
+    assert "x-thinking-budget-max-tokens-floor" not in headers
+
+
+def test_helper_applied_false():
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=8192,
+        source=EffortSource.OUTPUT_CONFIG_EFFORT,
+        max_tokens_floor=16384,
+        effort_label="high",
+    )
+    headers = _build_thinking_budget_headers(resolved, applied=False)
+    assert headers["x-thinking-budget-applied"] == "false"
+    assert headers["x-thinking-budget-resolved"] == "8192"
+    assert headers["x-thinking-budget-source"] == "output_config_effort"
+    assert headers["x-thinking-budget-max-tokens-floor"] == "16384"
+
+
+def test_helper_zero_budget_omits_floor():
+    """budget=0 means 'no thinking' — max_tokens_floor doesn't apply."""
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=0,
+        source=EffortSource.ANTHROPIC_THINKING_DISABLED,
+        max_tokens_floor=None,
+        effort_label=None,
+    )
+    headers = _build_thinking_budget_headers(resolved, applied=True)
+    assert headers["x-thinking-budget-resolved"] == "0"
+    assert "x-thinking-budget-max-tokens-floor" not in headers

--- a/tests/test_thinking_budget_matrix.py
+++ b/tests/test_thinking_budget_matrix.py
@@ -426,3 +426,133 @@ def test_anthropic_messages_path_honors_budget(spec: ModelSpec) -> None:
     # Soft latency check — Anthropic path shouldn't be dramatically
     # slower than OpenAI.
     assert elapsed < _TIMEOUT_SEC * 0.5
+
+
+# ----- Provider-effort-unification: new input dialects ----------------
+#
+# These rows pin the end-to-end wiring of the resolver introduced in the
+# provider-effort-unification branch. Each case sends a distinct dialect
+# (output_config.effort low/medium/high/xhigh, thinking.adaptive,
+# top-level precedence over effort, OpenAI reasoning_effort) and asserts
+# on the two new response headers:
+#   x-thinking-budget-source   — which input field won precedence
+#   x-thinking-budget-resolved — the int (or "none") the resolver produced
+#
+# Unit coverage lives in tests/test_effort_resolver.py and
+# tests/test_thinking_budget_headers.py; this file is the HTTP-layer
+# smoke test that ties Pydantic validation → resolver → header emission
+# together against a live server.
+
+_MESSAGES_DIALECT_CASES: list[tuple[dict, str, str]] = [
+    # (body_patch, expected_source, expected_budget_str)
+    ({"output_config": {"effort": "low"}},    "output_config_effort",        "512"),
+    ({"output_config": {"effort": "medium"}}, "output_config_effort",        "2048"),
+    ({"output_config": {"effort": "high"}},   "output_config_effort",        "8192"),
+    ({"output_config": {"effort": "xhigh"}},  "output_config_effort",        "16384"),
+    ({"thinking": {"type": "adaptive"}},      "anthropic_thinking_adaptive", "none"),
+    # top-level budget MUST win even when effort="max" is also sent.
+    ({
+        "thinking_token_budget": 777,
+        "output_config": {"effort": "max"},
+    },                                         "top_level",                   "777"),
+]
+
+
+def _dialect_ids(case: tuple[dict, str, str]) -> str:
+    return case[1]
+
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+@pytest.mark.parametrize(
+    "body_patch,expected_source,expected_budget_str",
+    _MESSAGES_DIALECT_CASES,
+    ids=[c[1] for c in _MESSAGES_DIALECT_CASES],
+)
+def test_messages_header_matrix(
+    spec: ModelSpec,
+    body_patch: dict,
+    expected_source: str,
+    expected_budget_str: str,
+) -> None:
+    """HTTP-level matrix: every new Anthropic input dialect produces the
+    documented source + resolved header values against a live server.
+
+    This does NOT assert on generation behavior — just that the request
+    parsed, reached the resolver, and the resolver's answer rode back
+    out on the response headers. Generation-behavior invariants live in
+    the tests above (ordering, budget=0 latency, etc.).
+    """
+    _require_matrix()
+
+    body: dict[str, Any] = {
+        "model": spec.model,
+        "messages": [{"role": "user", "content": PROMPT_TRIVIAL}],
+        "max_tokens": 32,
+        "temperature": 0.3,
+        **body_patch,
+    }
+    resp = requests.post(
+        f"{spec.url}/v1/messages",
+        json=body,
+        timeout=_TIMEOUT_SEC,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert resp.headers.get("x-thinking-budget-source") == expected_source, (
+        f"{spec.name}: dialect={body_patch!r} — expected source="
+        f"{expected_source!r}, got "
+        f"{resp.headers.get('x-thinking-budget-source')!r}"
+    )
+    assert resp.headers.get("x-thinking-budget-resolved") == expected_budget_str, (
+        f"{spec.name}: dialect={body_patch!r} — expected resolved="
+        f"{expected_budget_str!r}, got "
+        f"{resp.headers.get('x-thinking-budget-resolved')!r}"
+    )
+
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+@pytest.mark.parametrize(
+    "reasoning_effort,expected_budget_str",
+    [
+        ("low",    "512"),
+        ("medium", "2048"),
+        ("high",   "8192"),
+    ],
+)
+def test_chat_completions_reasoning_effort(
+    spec: ModelSpec,
+    reasoning_effort: str,
+    expected_budget_str: str,
+) -> None:
+    """OpenAI reasoning_effort round-trips end-to-end.
+
+    The /v1/chat/completions path accepts reasoning_effort natively;
+    this pins that it flows through ChatCompletionRequest → resolver →
+    response headers with the documented budget values.
+    """
+    _require_matrix()
+
+    body: dict[str, Any] = {
+        "model": spec.model,
+        "messages": [{"role": "user", "content": PROMPT_TRIVIAL}],
+        "max_tokens": 32,
+        "temperature": 0.3,
+        "reasoning_effort": reasoning_effort,
+    }
+    resp = requests.post(
+        f"{spec.url}/v1/chat/completions",
+        json=body,
+        timeout=_TIMEOUT_SEC,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert resp.headers.get("x-thinking-budget-source") == "reasoning_effort", (
+        f"{spec.name}: reasoning_effort={reasoning_effort!r} — expected "
+        f"source=reasoning_effort, got "
+        f"{resp.headers.get('x-thinking-budget-source')!r}"
+    )
+    assert resp.headers.get("x-thinking-budget-resolved") == expected_budget_str, (
+        f"{spec.name}: reasoning_effort={reasoning_effort!r} — expected "
+        f"resolved={expected_budget_str!r}, got "
+        f"{resp.headers.get('x-thinking-budget-resolved')!r}"
+    )

--- a/tests/test_thinking_budget_matrix.py
+++ b/tests/test_thinking_budget_matrix.py
@@ -51,7 +51,6 @@ from typing import Any
 import pytest
 import requests
 
-
 pytestmark = pytest.mark.integration
 
 
@@ -187,6 +186,7 @@ def _chat(
 
 # ----- Supported-family invariants -------------------------------------
 
+
 @pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
 def test_budget_zero_is_fast_and_silent_on_thinking(spec: ModelSpec) -> None:
     """budget=0: on a reasoning model, thinking MUST be force-closed
@@ -306,8 +306,9 @@ def test_budget_zero_is_faster_than_unbounded(spec: ModelSpec) -> None:
     """
     _require_matrix()
     if spec.family != "supported":
-        pytest.skip(f"{spec.name}: latency assertion only meaningful for "
-                    "supported family")
+        pytest.skip(
+            f"{spec.name}: latency assertion only meaningful for " "supported family"
+        )
 
     # Warm the server with unbounded first, THEN measure budget=0 so the
     # warm-up cost is absorbed by the unbounded cell.
@@ -323,6 +324,7 @@ def test_budget_zero_is_faster_than_unbounded(spec: ModelSpec) -> None:
 
 # ----- Graceful wrap-up message ---------------------------------------
 
+
 @pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
 def test_thinking_budget_message_produces_transition(
     spec: ModelSpec,
@@ -333,8 +335,7 @@ def test_thinking_budget_message_produces_transition(
     """
     _require_matrix()
     if spec.family != "supported":
-        pytest.skip(f"{spec.name}: message feature only runs on supported "
-                    "family")
+        pytest.skip(f"{spec.name}: message feature only runs on supported " "family")
 
     hint = "Wrap up and answer now."
     # Fetch the raw response so we can inspect the reasoning block text.
@@ -347,7 +348,9 @@ def test_thinking_budget_message_produces_transition(
         "thinking_budget_message": hint,
     }
     resp = requests.post(
-        f"{spec.url}/v1/chat/completions", json=body, timeout=_TIMEOUT_SEC,
+        f"{spec.url}/v1/chat/completions",
+        json=body,
+        timeout=_TIMEOUT_SEC,
     )
     resp.raise_for_status()
     assert resp.headers.get("x-thinking-budget-applied") == "true"
@@ -360,8 +363,10 @@ def test_thinking_budget_message_produces_transition(
     # A distinctive substring from the hint should survive tokenization.
     # "Wrap up" is the highest-signal phrase; if the tokenizer splits it
     # weirdly, fall back to checking "answer" which is also in the hint.
-    hit = ("Wrap up" in reasoning) or ("wrap up" in reasoning) or (
-        "answer" in reasoning.lower()
+    hit = (
+        ("Wrap up" in reasoning)
+        or ("wrap up" in reasoning)
+        or ("answer" in reasoning.lower())
     )
     assert hit, (
         f"{spec.name}: expected wrap-up hint to appear in reasoning "
@@ -370,6 +375,7 @@ def test_thinking_budget_message_produces_transition(
 
 
 # ----- Anthropic /v1/messages plumbing --------------------------------
+
 
 @pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
 def test_anthropic_messages_path_honors_budget(spec: ModelSpec) -> None:
@@ -380,8 +386,7 @@ def test_anthropic_messages_path_honors_budget(spec: ModelSpec) -> None:
     """
     _require_matrix()
     if spec.family != "supported":
-        pytest.skip(f"{spec.name}: Anthropic plumbing test only on "
-                    "supported family")
+        pytest.skip(f"{spec.name}: Anthropic plumbing test only on " "supported family")
 
     body = {
         "model": spec.model,
@@ -407,22 +412,18 @@ def test_anthropic_messages_path_honors_budget(spec: ModelSpec) -> None:
     data = resp.json()
     blocks = data.get("content") or []
     thinking_chars = sum(
-        len(b.get("thinking", "") or "")
-        for b in blocks
-        if b.get("type") == "thinking"
+        len(b.get("thinking", "") or "") for b in blocks if b.get("type") == "thinking"
     )
     text_chars = sum(
-        len(b.get("text", "") or "")
-        for b in blocks
-        if b.get("type") == "text"
+        len(b.get("text", "") or "") for b in blocks if b.get("type") == "text"
     )
     assert thinking_chars <= 50, (
         f"{spec.name}: budget=0 via Anthropic produced {thinking_chars} "
         f"thinking chars; expected ~0"
     )
-    assert text_chars > 0, (
-        f"{spec.name}: Anthropic must still produce an answer at budget=0"
-    )
+    assert (
+        text_chars > 0
+    ), f"{spec.name}: Anthropic must still produce an answer at budget=0"
     # Soft latency check — Anthropic path shouldn't be dramatically
     # slower than OpenAI.
     assert elapsed < _TIMEOUT_SEC * 0.5
@@ -445,16 +446,20 @@ def test_anthropic_messages_path_honors_budget(spec: ModelSpec) -> None:
 
 _MESSAGES_DIALECT_CASES: list[tuple[dict, str, str]] = [
     # (body_patch, expected_source, expected_budget_str)
-    ({"output_config": {"effort": "low"}},    "output_config_effort",        "512"),
-    ({"output_config": {"effort": "medium"}}, "output_config_effort",        "2048"),
-    ({"output_config": {"effort": "high"}},   "output_config_effort",        "8192"),
-    ({"output_config": {"effort": "xhigh"}},  "output_config_effort",        "16384"),
-    ({"thinking": {"type": "adaptive"}},      "anthropic_thinking_adaptive", "none"),
+    ({"output_config": {"effort": "low"}}, "output_config_effort", "512"),
+    ({"output_config": {"effort": "medium"}}, "output_config_effort", "2048"),
+    ({"output_config": {"effort": "high"}}, "output_config_effort", "8192"),
+    ({"output_config": {"effort": "xhigh"}}, "output_config_effort", "16384"),
+    ({"thinking": {"type": "adaptive"}}, "anthropic_thinking_adaptive", "none"),
     # top-level budget MUST win even when effort="max" is also sent.
-    ({
-        "thinking_token_budget": 777,
-        "output_config": {"effort": "max"},
-    },                                         "top_level",                   "777"),
+    (
+        {
+            "thinking_token_budget": 777,
+            "output_config": {"effort": "max"},
+        },
+        "top_level",
+        "777",
+    ),
 ]
 
 
@@ -514,9 +519,9 @@ def test_messages_header_matrix(
 @pytest.mark.parametrize(
     "reasoning_effort,expected_budget_str",
     [
-        ("low",    "512"),
+        ("low", "512"),
         ("medium", "2048"),
-        ("high",   "8192"),
+        ("high", "8192"),
     ],
 )
 def test_chat_completions_reasoning_effort(

--- a/tests/test_thinking_budget_rebase_sentinel.py
+++ b/tests/test_thinking_budget_rebase_sentinel.py
@@ -111,17 +111,22 @@ class TestThinkingBudgetSentinel:
         DCR Wave-3: Wave-2 sentinel only covered the Anthropic handler,
         but invariant #9 claims both chat-completion handlers emit the
         header. Deleting the OpenAI emission silently passed all 63
-        tests before this assertion."""
+        tests before this assertion.
+
+        Task 9 refactored emission to go through `_build_thinking_budget_headers`,
+        which also emits x-thinking-budget-resolved/source/max-tokens-floor.
+        The sentinel now counts calls to that helper (>=2 = streaming +
+        non-streaming branches)."""
         import inspect
 
         from vllm_mlx import server
 
         src = inspect.getsource(server.create_chat_completion)
-        occurrences = src.count("x-thinking-budget-applied")
+        occurrences = src.count("_build_thinking_budget_headers")
         assert occurrences >= 2, (
-            f"create_chat_completion regression: x-thinking-budget-applied "
+            f"create_chat_completion regression: _build_thinking_budget_headers "
             f"appears only {occurrences} time(s) — expected >=2 (streaming + "
-            f"non-streaming branches)."
+            f"non-streaming branches). Clients lose budget-enforcement signal."
         )
 
     def test_streaming_header_call_sites_bind_engine_type(self):
@@ -162,18 +167,23 @@ class TestThinkingBudgetSentinel:
         Response/JSONResponse headers). `_stream_anthropic_messages` is
         the generator that yields SSE event bodies — it doesn't set
         HTTP headers.
+
+        Task 9 refactored emission to go through `_build_thinking_budget_headers`,
+        which also emits x-thinking-budget-resolved/source/max-tokens-floor.
+        The sentinel now counts calls to that helper (>=2 = streaming +
+        non-streaming branches).
         """
         import inspect
 
         from vllm_mlx import server
 
         src = inspect.getsource(server.create_anthropic_message)
-        # The header literal must appear at least twice: once for the
+        # The helper call must appear at least twice: once for the
         # streaming branch (StreamingResponse headers dict) and once for
         # the non-streaming branch (Response headers dict).
-        occurrences = src.count("x-thinking-budget-applied")
+        occurrences = src.count("_build_thinking_budget_headers")
         assert occurrences >= 2, (
-            f"create_anthropic_message regression: x-thinking-budget-applied "
+            f"create_anthropic_message regression: _build_thinking_budget_headers "
             f"appears only {occurrences} time(s) — expected >=2 (streaming + "
             f"non-streaming branches). Clients lose budget-enforcement signal."
         )

--- a/tests/test_thinking_budget_rebase_sentinel.py
+++ b/tests/test_thinking_budget_rebase_sentinel.py
@@ -8,8 +8,6 @@ surfacing a conflict.
 
 import inspect
 
-import pytest
-
 
 class TestThinkingBudgetSentinel:
     def test_sampling_params_has_fields(self):
@@ -354,11 +352,15 @@ class TestThinkingBudgetSentinel:
         # existing=True (happy path) + new=None (abort) → True preserved.
         existing_true = RequestOutput(request_id="x", thinking_budget_applied=True)
         new_none = RequestOutput(request_id="x", thinking_budget_applied=None)
-        assert coll._merge_outputs(existing_true, new_none).thinking_budget_applied is True
+        assert (
+            coll._merge_outputs(existing_true, new_none).thinking_budget_applied is True
+        )
         # Symmetric: existing=None + new=True → True wins.
         existing_none = RequestOutput(request_id="x", thinking_budget_applied=None)
         new_true = RequestOutput(request_id="x", thinking_budget_applied=True)
-        assert coll._merge_outputs(existing_none, new_true).thinking_budget_applied is True
+        assert (
+            coll._merge_outputs(existing_none, new_true).thinking_budget_applied is True
+        )
 
     def test_insert_call_accepts_logits_processors(self):
         """CRITICAL-2 (pre-mortem S2): _BG_INIT_PARAMS is derived from

--- a/vllm_mlx/api/__init__.py
+++ b/vllm_mlx/api/__init__.py
@@ -136,4 +136,8 @@ __all__ = [
     "validate_json_schema",
     "extract_json_from_text",
     "build_json_system_prompt",
+    # Effort / budget resolver
+    "EffortSource",
+    "ResolvedBudget",
+    "resolve_effort",
 ]

--- a/vllm_mlx/api/__init__.py
+++ b/vllm_mlx/api/__init__.py
@@ -75,6 +75,12 @@ from .tool_calling import (
     build_json_system_prompt,
 )
 
+from .effort import (
+    EffortSource,
+    ResolvedBudget,
+    resolve_effort,
+)
+
 __all__ = [
     # Models
     "ImageUrl",

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -135,7 +135,18 @@ def openai_to_anthropic(
     choice = response.choices[0] if response.choices else None
 
     if choice:
-        # Add text content
+        # Emit thinking block first when the reasoning parser populated .reasoning.
+        # Matches Anthropic's public API and the streaming path
+        # (server.py:1991-2032).
+        if choice.message.reasoning:
+            content.append(
+                AnthropicResponseContentBlock(
+                    type="thinking",
+                    thinking=choice.message.reasoning,
+                )
+            )
+
+        # Add text content (existing behavior).
         if choice.message.content:
             content.append(
                 AnthropicResponseContentBlock(

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -19,6 +19,7 @@ from .anthropic_models import (
     AnthropicToolDef,
     AnthropicUsage,
 )
+from .effort import ResolvedBudget, resolve_effort
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -27,7 +28,10 @@ from .models import (
 )
 
 
-def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
+def anthropic_to_openai(
+    request: AnthropicRequest,
+    context_window: int = 131072,
+) -> tuple[ChatCompletionRequest, ResolvedBudget]:
     """
     Convert an Anthropic Messages API request to OpenAI Chat Completions format.
 
@@ -37,11 +41,18 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
     - tool_use/tool_result → OpenAI tool_calls/tool messages
     - Anthropic tools → OpenAI tools
 
+    Returns a (ChatCompletionRequest, ResolvedBudget) tuple so the caller
+    can emit resolver-derived response headers. The ChatCompletionRequest's
+    thinking_token_budget is populated from the resolver; callers should
+    not read request.thinking_token_budget directly after this returns.
+
     Args:
         request: Anthropic Messages API request
+        context_window: model context window used for dynamic effort sizing
+            (e.g., "max" effort scales with ctx). Default 131072 when unknown.
 
     Returns:
-        OpenAI ChatCompletionRequest
+        (ChatCompletionRequest, ResolvedBudget)
     """
     messages = []
 
@@ -77,31 +88,19 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
     if request.tool_choice:
         tool_choice = _convert_tool_choice(request.tool_choice)
 
-    # Resolve thinking budget from the two parse paths:
-    #   (a) top-level thinking_token_budget (vllm-mlx extension)
-    #   (b) Anthropic-native `thinking` dict: {"type": "enabled"|"disabled",
-    #       "budget_tokens": N}
-    # Top-level wins. For the nested form, honor type:
-    #   - type="disabled" → budget=0 (force close immediately)
-    #   - type="enabled"  → budget=budget_tokens (may be None — no cap)
-    #   - type=<anything else> → ignore (log WARN, no budget)
-    thinking_token_budget = request.thinking_token_budget
-    if thinking_token_budget is None and isinstance(request.thinking, dict):
-        thinking_type = request.thinking.get("type")
-        if thinking_type == "disabled":
-            thinking_token_budget = 0
-        elif thinking_type in ("enabled", None):
-            thinking_token_budget = request.thinking.get("budget_tokens")
-        else:
-            import logging
+    # Resolve thinking budget via the shared resolver. Replaces the old
+    # inline thinking.type + thinking_token_budget resolution block.
+    # The resolver handles top-level vs Anthropic `thinking` (including
+    # "adaptive") vs output_config.effort precedence.
+    resolved = resolve_effort(
+        top_level_budget=request.thinking_token_budget,
+        anthropic_thinking=request.thinking,
+        output_config=request.output_config,
+        reasoning_effort=None,  # not on the Anthropic path
+        context_window=context_window,
+    )
 
-            logging.getLogger(__name__).warning(
-                "Anthropic request.thinking.type=%r not recognized; "
-                "ignoring thinking config. Expected 'enabled' or 'disabled'.",
-                thinking_type,
-            )
-
-    return ChatCompletionRequest(
+    openai_req = ChatCompletionRequest(
         model=request.model,
         messages=messages,
         max_tokens=request.max_tokens,
@@ -111,9 +110,11 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
         stop=request.stop_sequences,
         tools=tools,
         tool_choice=tool_choice,
-        thinking_token_budget=thinking_token_budget,
+        thinking_token_budget=resolved.budget,
         thinking_budget_message=request.thinking_budget_message,
     )
+
+    return openai_req, resolved
 
 
 def openai_to_anthropic(

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -100,8 +100,12 @@ class AnthropicUsage(BaseModel):
 class AnthropicResponseContentBlock(BaseModel):
     """A content block in the Anthropic response."""
 
-    type: str  # "text" or "tool_use"
+    type: str  # "text" | "thinking" | "tool_use"
     text: str | None = None
+    # Populated when type == "thinking" — the reasoning content from the
+    # attached reasoning parser's extracted <think>...</think> span.
+    # Distinct from text so clients can segment reasoning from the answer.
+    thinking: str | None = None
     # tool_use fields
     id: str | None = None
     name: str | None = None

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -76,6 +76,11 @@ class AnthropicRequest(BaseModel):
     # Capped at 2048 chars — see ChatCompletionRequest for rationale
     # (DoS prevention — DCR Wave-3 finding).
     thinking_budget_message: str | None = Field(default=None, max_length=2048)
+    # Claude Code's wire format for effort-based thinking budget selection.
+    # Normalized by vllm_mlx.api.effort.resolve_effort. Accepts
+    # {"effort": "low"|"medium"|"high"|"xhigh"|"max"}. Unknown values
+    # fall through to default behavior rather than erroring.
+    output_config: dict | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/api/effort.py
+++ b/vllm_mlx/api/effort.py
@@ -80,7 +80,51 @@ def resolve_effort(
 
     See module docstring for precedence order.
     """
-    # Scaffold: just return DEFAULT. Tasks 2-4 fill in the real logic.
+    # 1. Top-level explicit budget wins over everything.
+    if top_level_budget is not None:
+        return ResolvedBudget(
+            budget=top_level_budget,
+            source=EffortSource.TOP_LEVEL,
+            max_tokens_floor=None,
+            effort_label=None,
+        )
+
+    # 2. Anthropic thinking dict.
+    if isinstance(anthropic_thinking, dict):
+        thinking_type = anthropic_thinking.get("type")
+        if thinking_type == "disabled":
+            return ResolvedBudget(
+                budget=0,
+                source=EffortSource.ANTHROPIC_THINKING_DISABLED,
+                max_tokens_floor=None,
+                effort_label=None,
+            )
+        if thinking_type == "enabled":
+            return ResolvedBudget(
+                budget=anthropic_thinking.get("budget_tokens"),
+                source=EffortSource.ANTHROPIC_THINKING_ENABLED,
+                max_tokens_floor=None,
+                effort_label=None,
+            )
+        if thinking_type == "adaptive":
+            return ResolvedBudget(
+                budget=None,
+                source=EffortSource.ANTHROPIC_THINKING_ADAPTIVE,
+                max_tokens_floor=None,
+                effort_label=None,
+            )
+        if thinking_type is not None:
+            # Unknown type — log and fall through to lower-precedence signals
+            # or to DEFAULT. Matches the old adapter's WARN-on-unknown.
+            logger.warning(
+                "Unknown anthropic_thinking.type=%r; falling through to "
+                "lower-precedence signals or default.",
+                thinking_type,
+            )
+
+    # 5. output_config.effort and 6. reasoning_effort handled in Tasks 3-4.
+
+    # 7. Default.
     return ResolvedBudget(
         budget=None,
         source=EffortSource.DEFAULT,

--- a/vllm_mlx/api/effort.py
+++ b/vllm_mlx/api/effort.py
@@ -17,14 +17,20 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 
-class EffortSource(StrEnum):
+class EffortSource(str, Enum):
     """Which input field produced the resolved budget. Emitted as the
-    `x-thinking-budget-source` response header."""
+    `x-thinking-budget-source` response header.
+
+    Subclasses ``(str, Enum)`` rather than ``StrEnum`` for Python 3.10 compat
+    (StrEnum is 3.11+ only). Behaviorally equivalent: ``EffortSource.DEFAULT
+    == "default"`` is True, and the server's header emission uses
+    ``source.value`` so the wire format is identical either way.
+    """
 
     TOP_LEVEL = "top_level"
     ANTHROPIC_THINKING_DISABLED = "anthropic_thinking_disabled"

--- a/vllm_mlx/api/effort.py
+++ b/vllm_mlx/api/effort.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 class EffortSource(StrEnum):
     """Which input field produced the resolved budget. Emitted as the
     `x-thinking-budget-source` response header."""
+
     TOP_LEVEL = "top_level"
     ANTHROPIC_THINKING_DISABLED = "anthropic_thinking_disabled"
     ANTHROPIC_THINKING_ENABLED = "anthropic_thinking_enabled"
@@ -37,6 +38,7 @@ class EffortSource(StrEnum):
 @dataclass(frozen=True)
 class ResolvedBudget:
     """Result of resolving all budget-ish signals on a single request."""
+
     budget: int | None
     source: EffortSource
     max_tokens_floor: int | None
@@ -47,10 +49,10 @@ class ResolvedBudget:
 # max_tokens_floor is a client-side *hint* returned via
 # `x-thinking-budget-max-tokens-floor`; it is not enforced server-side.
 _EFFORT_TABLE: dict[str, tuple[int, int]] = {
-    "low":    (512,   2048),
-    "medium": (2048,  4096),
-    "high":   (8192,  16384),
-    "xhigh":  (16384, 32768),
+    "low": (512, 2048),
+    "medium": (2048, 4096),
+    "high": (8192, 16384),
+    "xhigh": (16384, 32768),
     # "max" is computed dynamically in resolve_effort — see below.
 }
 
@@ -61,7 +63,7 @@ _MAX_BUDGET_CAP: int = 65536
 # Synonyms — client vocabularies that mean the same thing.
 _EFFORT_ALIASES: dict[str, str] = {
     "minimal": "low",
-    "normal":  "medium",
+    "normal": "medium",
 }
 
 
@@ -127,7 +129,9 @@ def resolve_effort(
         raw_effort = output_config.get("effort")
         if raw_effort is not None:
             resolved = _resolve_effort_string(
-                raw_effort, context_window, EffortSource.OUTPUT_CONFIG_EFFORT,
+                raw_effort,
+                context_window,
+                EffortSource.OUTPUT_CONFIG_EFFORT,
             )
             if resolved is not None:
                 return resolved
@@ -135,7 +139,9 @@ def resolve_effort(
     # 6. OpenAI reasoning_effort.
     if reasoning_effort is not None:
         resolved = _resolve_effort_string(
-            reasoning_effort, context_window, EffortSource.REASONING_EFFORT,
+            reasoning_effort,
+            context_window,
+            EffortSource.REASONING_EFFORT,
         )
         if resolved is not None:
             return resolved
@@ -184,6 +190,7 @@ def _resolve_effort_string(
 
     logger.warning(
         "Unknown effort=%r (source=%s); falling through to DEFAULT.",
-        raw_effort, source,
+        raw_effort,
+        source,
     )
     return None

--- a/vllm_mlx/api/effort.py
+++ b/vllm_mlx/api/effort.py
@@ -122,7 +122,17 @@ def resolve_effort(
                 thinking_type,
             )
 
-    # 5. output_config.effort and 6. reasoning_effort handled in Tasks 3-4.
+    # 5. Anthropic output_config.effort (Claude Code wire format).
+    if isinstance(output_config, dict):
+        raw_effort = output_config.get("effort")
+        if raw_effort is not None:
+            resolved = _resolve_effort_string(
+                raw_effort, context_window, EffortSource.OUTPUT_CONFIG_EFFORT,
+            )
+            if resolved is not None:
+                return resolved
+
+    # 6. reasoning_effort handled in Task 4.
 
     # 7. Default.
     return ResolvedBudget(
@@ -131,3 +141,43 @@ def resolve_effort(
         max_tokens_floor=None,
         effort_label=None,
     )
+
+
+def _resolve_effort_string(
+    raw_effort: str,
+    context_window: int,
+    source: EffortSource,
+) -> ResolvedBudget | None:
+    """Look up an effort-style string in the table. Returns None if the string
+    is unknown (caller falls through to lower precedence / DEFAULT).
+
+    Preserves the raw client string in `effort_label` so the header reflects
+    what the client actually sent (e.g., "minimal" not "low").
+    """
+    canonical = _EFFORT_ALIASES.get(raw_effort, raw_effort)
+
+    if canonical == "max":
+        budget = min(context_window // 2, _MAX_BUDGET_CAP)
+        # max_tokens_floor: 2x budget, capped at 2x _MAX_BUDGET_CAP
+        floor = min(budget * 2, _MAX_BUDGET_CAP * 2)
+        return ResolvedBudget(
+            budget=budget,
+            source=source,
+            max_tokens_floor=floor,
+            effort_label=raw_effort,
+        )
+
+    if canonical in _EFFORT_TABLE:
+        budget, floor = _EFFORT_TABLE[canonical]
+        return ResolvedBudget(
+            budget=budget,
+            source=source,
+            max_tokens_floor=floor,
+            effort_label=raw_effort,
+        )
+
+    logger.warning(
+        "Unknown effort=%r (source=%s); falling through to DEFAULT.",
+        raw_effort, source,
+    )
+    return None

--- a/vllm_mlx/api/effort.py
+++ b/vllm_mlx/api/effort.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dialect-agnostic resolver for thinking_token_budget.
+
+Five provider-dialect signals can appear on a request:
+  1. Top-level `thinking_token_budget` (vllm-mlx extension, all paths)
+  2. Anthropic-native `thinking: {"type": ..., "budget_tokens": ...}`
+  3. Anthropic `output_config: {"effort": "low"|"medium"|"high"|"xhigh"|"max"}`
+  4. OpenAI-native `reasoning_effort: "low"|"medium"|"high"`
+  5. Nothing — natural behavior
+
+This module collapses all five into a single `ResolvedBudget`. See
+`docs/superpowers/specs/2026-04-18-provider-effort-budget-unification-design.md`
+for the precedence table and rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+
+logger = logging.getLogger(__name__)
+
+
+class EffortSource(StrEnum):
+    """Which input field produced the resolved budget. Emitted as the
+    `x-thinking-budget-source` response header."""
+    TOP_LEVEL = "top_level"
+    ANTHROPIC_THINKING_DISABLED = "anthropic_thinking_disabled"
+    ANTHROPIC_THINKING_ENABLED = "anthropic_thinking_enabled"
+    ANTHROPIC_THINKING_ADAPTIVE = "anthropic_thinking_adaptive"
+    OUTPUT_CONFIG_EFFORT = "output_config_effort"
+    REASONING_EFFORT = "reasoning_effort"
+    DEFAULT = "default"
+
+
+@dataclass(frozen=True)
+class ResolvedBudget:
+    """Result of resolving all budget-ish signals on a single request."""
+    budget: int | None
+    source: EffortSource
+    max_tokens_floor: int | None
+    effort_label: str | None
+
+
+# Canonical effort → (budget, max_tokens_floor) table.
+# max_tokens_floor is a client-side *hint* returned via
+# `x-thinking-budget-max-tokens-floor`; it is not enforced server-side.
+_EFFORT_TABLE: dict[str, tuple[int, int]] = {
+    "low":    (512,   2048),
+    "medium": (2048,  4096),
+    "high":   (8192,  16384),
+    "xhigh":  (16384, 32768),
+    # "max" is computed dynamically in resolve_effort — see below.
+}
+
+# Hard cap for "max" effort: min(context_window // 2, _MAX_BUDGET_CAP).
+# Keeps 1M-context models from burning 500k tokens on one reasoning pass.
+_MAX_BUDGET_CAP: int = 65536
+
+# Synonyms — client vocabularies that mean the same thing.
+_EFFORT_ALIASES: dict[str, str] = {
+    "minimal": "low",
+    "normal":  "medium",
+}
+
+
+def resolve_effort(
+    *,
+    top_level_budget: int | None = None,
+    anthropic_thinking: dict | None = None,
+    output_config: dict | None = None,
+    reasoning_effort: str | None = None,
+    context_window: int = 131072,
+) -> ResolvedBudget:
+    """Collapse all dialect signals into a single ResolvedBudget.
+
+    Pure function. No side effects. No exceptions on unknown effort strings —
+    those fall through to DEFAULT with a WARN log.
+
+    See module docstring for precedence order.
+    """
+    # Scaffold: just return DEFAULT. Tasks 2-4 fill in the real logic.
+    return ResolvedBudget(
+        budget=None,
+        source=EffortSource.DEFAULT,
+        max_tokens_floor=None,
+        effort_label=None,
+    )

--- a/vllm_mlx/api/effort.py
+++ b/vllm_mlx/api/effort.py
@@ -132,7 +132,13 @@ def resolve_effort(
             if resolved is not None:
                 return resolved
 
-    # 6. reasoning_effort handled in Task 4.
+    # 6. OpenAI reasoning_effort.
+    if reasoning_effort is not None:
+        resolved = _resolve_effort_string(
+            reasoning_effort, context_window, EffortSource.REASONING_EFFORT,
+        )
+        if resolved is not None:
+            return resolved
 
     # 7. Default.
     return ResolvedBudget(

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -219,6 +219,13 @@ class ChatCompletionRequest(BaseModel):
     # on the decode hot path (DCR Wave-3 finding).
     thinking_budget_message: str | None = Field(default=None, max_length=2048)
 
+    # OpenAI-native reasoning effort knob for o1/o3-family clients. Normalized
+    # through vllm_mlx.api.effort.resolve_effort. Accepted values include
+    # "low" | "medium" | "high" per OpenAI spec, plus "xhigh" | "max" and
+    # the synonyms "minimal" | "normal" via the shared effort table.
+    # Unknown strings WARN and fall through to DEFAULT rather than erroring.
+    reasoning_effort: str | None = None
+
 
 class AssistantMessage(BaseModel):
     """Response message from the assistant."""

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -552,9 +552,7 @@ def _parse_tool_calls_with_parser(
             tokenizer = _engine._tokenizer
         parser = parser_cls(tokenizer)
     except Exception as e:
-        logger.warning(
-            f"Failed to initialize tool parser '{_tool_call_parser}': {e}"
-        )
+        logger.warning(f"Failed to initialize tool parser '{_tool_call_parser}': {e}")
         logger.warning("Falling back to generic parser")
         return parse_tool_calls(output_text, request_dict)
 
@@ -1662,26 +1660,27 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 "window and content will be truncated or empty. Set "
                 "max_tokens >= thinking_token_budget + %d for content "
                 "headroom.",
-                _budget, request.max_tokens, _MIN_CONTENT_HEADROOM,
+                _budget,
+                request.max_tokens,
+                _MIN_CONTENT_HEADROOM,
             )
         elif request.max_tokens - _budget < _MIN_CONTENT_HEADROOM:
             logger.warning(
                 "thinking_token_budget=%d leaves only %d tokens of content "
                 "headroom under max_tokens=%d. Response content may be "
                 "truncated. Set max_tokens >= %d for safer sizing.",
-                _budget, request.max_tokens - _budget, request.max_tokens,
+                _budget,
+                request.max_tokens - _budget,
+                request.max_tokens,
                 _budget + _MIN_CONTENT_HEADROOM,
             )
 
     # Was a budget requested by the client? Used to decide whether to emit
     # the x-thinking-budget-applied response header for both streaming and
     # non-streaming paths.
-    budget_was_requested = (
-        request.thinking_token_budget is not None
-        or (
-            isinstance(request.chat_template_kwargs, dict)
-            and "thinking_token_budget" in request.chat_template_kwargs
-        )
+    budget_was_requested = request.thinking_token_budget is not None or (
+        isinstance(request.chat_template_kwargs, dict)
+        and "thinking_token_budget" in request.chat_template_kwargs
     )
 
     # Resolve thinking budget from all provider-dialect signals. This also
@@ -1690,8 +1689,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # TODO(context_window): thread from loaded model config.
     _resolved_budget = resolve_effort(
         top_level_budget=request.thinking_token_budget,
-        anthropic_thinking=None,        # not on OpenAI path
-        output_config=None,             # not on OpenAI path
+        anthropic_thinking=None,  # not on OpenAI path
+        output_config=None,  # not on OpenAI path
         reasoning_effort=request.reasoning_effort,
         context_window=131072,
     )
@@ -2316,7 +2315,8 @@ async def _stream_anthropic_messages(
             "Reasoning parser %s missing expected properties %r — upstream API "
             "drift? Falling back to default router (reasoning blocks will not "
             "be routed for this parser).",
-            type(_rp).__name__, _EXPECTED_PROPS,
+            type(_rp).__name__,
+            _EXPECTED_PROPS,
         )
         _start_token = "<think>"
         _end_tokens = ["</think>"]
@@ -2333,7 +2333,11 @@ async def _stream_anthropic_messages(
 
     logger.info(
         "StreamingThinkRouter: parser=%s start=%r end=%r strip=%r start_in_thinking=%r",
-        _parser_label, _start_token, _end_tokens, _channel_strip, _starts_thinking,
+        _parser_label,
+        _start_token,
+        _end_tokens,
+        _channel_strip,
+        _starts_thinking,
     )
 
     think_router = StreamingThinkRouter(
@@ -2527,12 +2531,16 @@ def _process_streaming_tool_delta(
     function -- a bug fix here fixes both paths.
     """
     if tool_parser is None or content is None:
-        return ToolDeltaResult(content, tool_accumulated_text, tool_markup_possible, False, None)
+        return ToolDeltaResult(
+            content, tool_accumulated_text, tool_markup_possible, False, None
+        )
 
     # Fast path: skip parsing until '<' seen
     if not tool_markup_possible and "<" not in content:
         tool_accumulated_text += content
-        return ToolDeltaResult(content, tool_accumulated_text, tool_markup_possible, False, None)
+        return ToolDeltaResult(
+            content, tool_accumulated_text, tool_markup_possible, False, None
+        )
 
     if not tool_markup_possible:
         tool_markup_possible = True
@@ -2543,12 +2551,18 @@ def _process_streaming_tool_delta(
     )
 
     if tool_result is None:
-        return ToolDeltaResult(None, tool_accumulated_text, tool_markup_possible, False, None)
+        return ToolDeltaResult(
+            None, tool_accumulated_text, tool_markup_possible, False, None
+        )
     elif "tool_calls" in tool_result:
-        return ToolDeltaResult(None, tool_accumulated_text, tool_markup_possible, True, tool_result)
+        return ToolDeltaResult(
+            None, tool_accumulated_text, tool_markup_possible, True, tool_result
+        )
     else:
         new_content = tool_result.get("content", "")
-        return ToolDeltaResult(new_content, tool_accumulated_text, tool_markup_possible, False, None)
+        return ToolDeltaResult(
+            new_content, tool_accumulated_text, tool_markup_possible, False, None
+        )
 
 
 async def stream_chat_completion(
@@ -2605,7 +2619,11 @@ async def stream_chat_completion(
     tool_markup_possible = False  # Fast path: skip parsing until '<' seen
     # tool_choice="none" prevents tool_parser init, which also guards the
     # streaming fallback block (it checks `if tool_parser`).
-    if _enable_auto_tool_choice and _tool_call_parser and getattr(request, "tool_choice", None) != "none":
+    if (
+        _enable_auto_tool_choice
+        and _tool_call_parser
+        and getattr(request, "tool_choice", None) != "none"
+    ):
         # Create per-request parser instance to avoid concurrency corruption
         try:
             parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
@@ -2685,9 +2703,7 @@ async def stream_chat_completion(
                         finish_reason=(
                             "tool_calls"
                             if (output.finished and tool_calls_detected)
-                            else (
-                                output.finish_reason if output.finished else None
-                            )
+                            else (output.finish_reason if output.finished else None)
                         ),
                     )
                 ],
@@ -2761,7 +2777,10 @@ async def stream_chat_completion(
         tool_parser
         and tool_accumulated_text
         and not tool_calls_detected
-        and ("<tool_call>" in tool_accumulated_text or "<|tool_call>" in tool_accumulated_text)
+        and (
+            "<tool_call>" in tool_accumulated_text
+            or "<|tool_call>" in tool_accumulated_text
+        )
     ):
         result = tool_parser.extract_tool_calls(tool_accumulated_text)
         if result.tools_called:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -60,6 +60,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 # Re-export for backwards compatibility with tests
 from .api.anthropic_adapter import anthropic_to_openai, openai_to_anthropic
 from .api.anthropic_models import AnthropicRequest
+from .api.effort import EffortSource, ResolvedBudget, resolve_effort  # noqa: F401
 from .api.models import (
     AssistantMessage,  # noqa: F401
     ChatCompletionChoice,  # noqa: F401
@@ -196,6 +197,38 @@ def _streaming_header_value(
     if reasoning_parser is None:
         return "false"
     return "true"
+
+
+def _build_thinking_budget_headers(
+    resolved: ResolvedBudget,
+    applied: bool | None,
+) -> dict[str, str]:
+    """Build the four x-thinking-budget-* response headers from a ResolvedBudget.
+
+    `applied` is the pre-existing bool/None the emission sites were computing
+    before this change (based on whether the logits processor attached and the
+    family can enforce). It stays separate because applied = "did it actually
+    work" != resolved = "what did we decide to try."
+    """
+    headers: dict[str, str] = {}
+
+    # 1. x-thinking-budget-applied (existing header, unchanged semantics).
+    if applied is not None:
+        headers["x-thinking-budget-applied"] = "true" if applied else "false"
+
+    # 2. x-thinking-budget-resolved — the int (or "none") the resolver produced.
+    headers["x-thinking-budget-resolved"] = (
+        str(resolved.budget) if resolved.budget is not None else "none"
+    )
+
+    # 3. x-thinking-budget-source — which field won precedence.
+    headers["x-thinking-budget-source"] = resolved.source.value
+
+    # 4. x-thinking-budget-max-tokens-floor — recommended min max_tokens.
+    if resolved.max_tokens_floor is not None:
+        headers["x-thinking-budget-max-tokens-floor"] = str(resolved.max_tokens_floor)
+
+    return headers
 
 
 def _anthropic_budget_requested(anthropic_request) -> bool:
@@ -1562,6 +1595,30 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         )
     )
 
+    # Resolve thinking budget from all provider-dialect signals. This also
+    # wires OpenAI `reasoning_effort` into the engine path (previously only
+    # the Anthropic adapter called the resolver).
+    # TODO(context_window): thread from loaded model config.
+    _resolved_budget = resolve_effort(
+        top_level_budget=request.thinking_token_budget,
+        anthropic_thinking=None,        # not on OpenAI path
+        output_config=None,             # not on OpenAI path
+        reasoning_effort=request.reasoning_effort,
+        context_window=131072,
+    )
+    # If reasoning_effort supplied a budget and top-level did not, propagate
+    # the resolved value downstream so the engine sees it.
+    if (
+        request.thinking_token_budget is None
+        and _resolved_budget.budget is not None
+        and _resolved_budget.source != EffortSource.DEFAULT
+    ):
+        request.thinking_token_budget = _resolved_budget.budget
+        chat_kwargs["thinking_token_budget"] = _resolved_budget.budget
+        # A resolved budget from reasoning_effort also counts as "requested"
+        # for header-emission purposes.
+        budget_was_requested = True
+
     # Add tools if provided
     if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
@@ -1577,7 +1634,19 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 reasoning_parser=getattr(engine, "_reasoning_parser", None),
                 engine_supports_budget=isinstance(engine, BatchedEngine),
             )
-            stream_headers["x-thinking-budget-applied"] = streaming_applied
+            stream_headers.update(
+                _build_thinking_budget_headers(
+                    _resolved_budget,
+                    applied=(streaming_applied == "true"),
+                )
+            )
+        elif _resolved_budget.source != EffortSource.DEFAULT:
+            # Resolver produced a non-default value (e.g. reasoning_effort)
+            # even though budget_was_requested is False. Emit diagnostic
+            # headers but skip x-thinking-budget-applied (applied=None).
+            stream_headers.update(
+                _build_thinking_budget_headers(_resolved_budget, applied=None)
+            )
         return StreamingResponse(
             _disconnect_guard(
                 stream_chat_completion(engine, messages, request, **chat_kwargs),
@@ -1666,9 +1735,21 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         applied = getattr(output, "thinking_budget_applied", None)
         return JSONResponse(
             content=chat_response.model_dump(mode="json", exclude_none=True),
-            headers={
-                "x-thinking-budget-applied": "true" if applied is True else "false"
-            },
+            headers=_build_thinking_budget_headers(
+                _resolved_budget,
+                applied=(applied is True),
+            ),
+        )
+
+    # Resolver produced a non-default value (e.g. from reasoning_effort) but
+    # budget_was_requested was False — surface diagnostic headers so callers
+    # see what the resolver chose, without claiming enforcement status.
+    if _resolved_budget.source != EffortSource.DEFAULT:
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            content=chat_response.model_dump(mode="json", exclude_none=True),
+            headers=_build_thinking_budget_headers(_resolved_budget, applied=None),
         )
 
     return chat_response
@@ -1750,19 +1831,33 @@ async def create_anthropic_message(
     )
     logger.info(f"[REQUEST] last user message preview: {last_user_preview!r}")
 
-    # Convert Anthropic request -> OpenAI request. The adapter now returns
-    # a (ChatCompletionRequest, ResolvedBudget) tuple; Task 9 will wire the
-    # resolved budget into x-thinking-* response headers at this site.
-    # TODO(Task 9): plumb real context_window from the loaded model config.
+    # Convert Anthropic request -> OpenAI request. The adapter returns
+    # a (ChatCompletionRequest, ResolvedBudget) tuple; we wire the resolved
+    # budget into x-thinking-* response headers at both emission sites below.
+    # TODO(context_window): plumb real context_window from the loaded model
+    # config (the adapter defaults to 131072 today).
     openai_request, _resolved_budget = anthropic_to_openai(anthropic_request)
 
     if anthropic_request.stream:
         headers = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
         if _anthropic_budget_requested(anthropic_request):
-            headers["x-thinking-budget-applied"] = _streaming_header_value(
+            streaming_applied = _streaming_header_value(
                 is_mllm=getattr(engine, "_is_mllm", False),
                 reasoning_parser=getattr(engine, "_reasoning_parser", None),
                 engine_supports_budget=isinstance(engine, BatchedEngine),
+            )
+            headers.update(
+                _build_thinking_budget_headers(
+                    _resolved_budget,
+                    applied=(streaming_applied == "true"),
+                )
+            )
+        elif _resolved_budget.source != EffortSource.DEFAULT:
+            # Resolver produced a non-default value (e.g. output_config.effort)
+            # without a nested thinking dict / top-level budget — surface
+            # diagnostic headers without claiming enforcement status.
+            headers.update(
+                _build_thinking_budget_headers(_resolved_budget, applied=None)
             )
         return StreamingResponse(
             _disconnect_guard(
@@ -1848,11 +1943,21 @@ async def create_anthropic_message(
 
     # Convert to Anthropic response
     anthropic_response = openai_to_anthropic(openai_response, _model_name)
-    _resp_headers = {}
+    _resp_headers: dict[str, str] = {}
     if _anthropic_budget_requested(anthropic_request):
         applied = getattr(output, "thinking_budget_applied", None)
-        _resp_headers["x-thinking-budget-applied"] = (
-            "true" if applied is True else "false"
+        _resp_headers.update(
+            _build_thinking_budget_headers(
+                _resolved_budget,
+                applied=(applied is True),
+            )
+        )
+    elif _resolved_budget.source != EffortSource.DEFAULT:
+        # Resolver produced a non-default value (e.g. output_config.effort)
+        # without a nested thinking dict / top-level budget — surface
+        # diagnostic headers without claiming enforcement status.
+        _resp_headers.update(
+            _build_thinking_budget_headers(_resolved_budget, applied=None)
         )
     return Response(
         content=anthropic_response.model_dump_json(exclude_none=True),

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1750,8 +1750,11 @@ async def create_anthropic_message(
     )
     logger.info(f"[REQUEST] last user message preview: {last_user_preview!r}")
 
-    # Convert Anthropic request -> OpenAI request
-    openai_request = anthropic_to_openai(anthropic_request)
+    # Convert Anthropic request -> OpenAI request. The adapter now returns
+    # a (ChatCompletionRequest, ResolvedBudget) tuple; Task 9 will wire the
+    # resolved budget into x-thinking-* response headers at this site.
+    # TODO(Task 9): plumb real context_window from the loaded model config.
+    openai_request, _resolved_budget = anthropic_to_openai(anthropic_request)
 
     if anthropic_request.stream:
         headers = {"Cache-Control": "no-cache", "Connection": "keep-alive"}

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -300,6 +300,52 @@ def _save_prefix_cache_to_disk() -> None:
         logger.warning(f"[lifespan] Failed to save cache to disk: {e}", exc_info=True)
 
 
+class _PrefixCacheEndpointAdapter:
+    """Thin adapter that exposes .clear() and .get_stats() for HTTP endpoints.
+
+    The real prefix cache (MemoryAwarePrefixCache / PrefixCacheManager /
+    BlockAwarePrefixCache) lives on the scheduler and is not directly exposed
+    by BatchedEngine. This adapter bridges the gap so GET /v1/cache/stats and
+    DELETE /v1/cache can operate on it uniformly.
+    """
+
+    def __init__(self, engine):
+        self._engine = engine
+
+    def _scheduler(self):
+        # BatchedEngine._engine is an AsyncEngineCore; its .engine is the core
+        # engine that owns the scheduler.
+        core = getattr(self._engine, "_engine", None)
+        if core is None:
+            return None
+        inner = getattr(core, "engine", None) or core
+        return getattr(inner, "scheduler", None)
+
+    def get_stats(self):
+        """Return whichever cache-tier stats the scheduler reports."""
+        scheduler = self._scheduler()
+        if scheduler is None:
+            return None
+        # Prefer explicit get_cache_stats(); fall back to inspecting cache objs.
+        if hasattr(scheduler, "get_cache_stats"):
+            return scheduler.get_cache_stats()
+        for attr in ("memory_aware_cache", "block_aware_cache", "prefix_cache"):
+            cache = getattr(scheduler, attr, None)
+            if cache is not None and hasattr(cache, "get_stats"):
+                return cache.get_stats()
+        return None
+
+    def clear(self):
+        """Clear every prefix cache tier the scheduler holds."""
+        scheduler = self._scheduler()
+        if scheduler is None:
+            return
+        for attr in ("memory_aware_cache", "block_aware_cache", "prefix_cache"):
+            cache = getattr(scheduler, attr, None)
+            if cache is not None and hasattr(cache, "clear"):
+                cache.clear()
+
+
 def _get_cache_dir() -> str:
     """Get cache persistence directory based on actual model path."""
     # Use _model_path (actual model path) not _model_name (which may be overridden
@@ -330,6 +376,15 @@ async def lifespan(app: FastAPI):
     # Load persisted cache from disk (AFTER engine start — AsyncEngineCore must exist)
     if _engine is not None and hasattr(_engine, "load_cache_from_disk"):
         _load_prefix_cache_from_disk()
+
+    # Expose prefix cache to HTTP endpoints via app.state. The adapter is safe
+    # to attach unconditionally — it no-ops when no scheduler / cache tier is
+    # actually present. Endpoints still use getattr(..., None) defensively so
+    # a missing attribute (in tests that clear state) is handled gracefully.
+    if _engine is not None:
+        app.state.prefix_cache = _PrefixCacheEndpointAdapter(_engine)
+    else:
+        app.state.prefix_cache = None
 
     # Initialize MCP if config provided
     mcp_config = os.environ.get("VLLM_MLX_MCP_CONFIG")
@@ -757,7 +812,23 @@ async def status():
 
 @app.get("/v1/cache/stats")
 async def cache_stats():
-    """Get cache statistics for debugging and monitoring."""
+    """Get cache statistics for debugging and monitoring.
+
+    Surfaces whichever cache tiers are actually present on this server:
+    - LLM prefix cache (MemoryAwarePrefixCache) when running an LLM
+    - mlx_vlm multimodal tiers (KV / pixel-values / PIL) when running a VLM
+    """
+    stats: dict[str, object] = {}
+
+    # LLM prefix cache stats — only present when the engine exposes one.
+    prefix_cache = getattr(app.state, "prefix_cache", None)
+    if prefix_cache is not None:
+        try:
+            stats["llm_prefix_cache"] = prefix_cache.get_stats()
+        except Exception as e:
+            stats["llm_prefix_cache_error"] = str(e)
+
+    # mlx_vlm multimodal stats — only importable when serving a VLM.
     try:
         from mlx_vlm.utils import (
             get_multimodal_kv_cache_stats,
@@ -765,18 +836,33 @@ async def cache_stats():
             get_pixel_values_cache_stats,
         )
 
-        return {
-            "multimodal_kv_cache": get_multimodal_kv_cache_stats(),
-            "pixel_values_cache": get_pixel_values_cache_stats(),
-            "pil_image_cache": get_pil_cache_stats(),
-        }
+        stats["multimodal_kv_cache"] = get_multimodal_kv_cache_stats()
+        stats["pixel_values_cache"] = get_pixel_values_cache_stats()
+        stats["pil_image_cache"] = get_pil_cache_stats()
     except ImportError:
-        return {"error": "Cache stats not available (mlx_vlm not loaded)"}
+        pass  # not a VLM server; not an error
+
+    if not stats:
+        return {"error": "No cache tiers present"}
+    return stats
 
 
 @app.delete("/v1/cache")
 async def clear_cache():
-    """Clear all caches."""
+    """Clear all caches held by this server (LLM prefix + mlx_vlm tiers)."""
+    cleared: list[str] = []
+    errors: list[str] = []
+
+    # LLM prefix cache (MemoryAwarePrefixCache) — only present when configured.
+    prefix_cache = getattr(app.state, "prefix_cache", None)
+    if prefix_cache is not None:
+        try:
+            prefix_cache.clear()
+            cleared.append("llm_prefix")
+        except Exception as e:
+            errors.append(f"llm_prefix: {e}")
+
+    # mlx_vlm multimodal caches — only importable when serving a VLM.
     try:
         from mlx_vlm.utils import (
             clear_multimodal_kv_cache,
@@ -785,12 +871,15 @@ async def clear_cache():
 
         clear_multimodal_kv_cache()
         clear_pixel_values_cache()
-        return {
-            "status": "cleared",
-            "caches": ["multimodal_kv", "pixel_values", "pil_image"],
-        }
+        cleared.extend(["multimodal_kv", "pixel_values", "pil_image"])
     except ImportError:
-        return {"error": "Cache clear not available (mlx_vlm not loaded)"}
+        pass  # not a VLM server; not an error
+
+    return {
+        "status": "cleared" if cleared else "noop",
+        "caches": cleared,
+        "errors": errors or None,
+    }
 
 
 @app.get("/v1/models", dependencies=[Depends(verify_api_key)])


### PR DESCRIPTION
## Summary

Unified resolver for `thinking_token_budget` that normalizes five provider dialects into a single ResolvedBudget:

- Top-level `thinking_token_budget` (already worked, now routes through the resolver)
- Anthropic `thinking.type: "enabled" | "disabled"` + `budget_tokens` (already worked, now routes through the resolver)
- Anthropic `thinking.type: "adaptive"` (NEW — was WARN-and-ignore, now a first-class signal)
- Anthropic `output_config.effort` (NEW — Claude Code's `--effort` flag wire format)
- OpenAI `reasoning_effort` (NEW — OpenAI-native o1-style knob)

Adjacent improvement: `DELETE /v1/cache` and `GET /v1/cache/stats` now cover the LLM `MemoryAwarePrefixCache`, not just the mlx_vlm multimodal caches. Operators can purge poisoned prefix entries without a full process restart.

New response headers surface resolver output for downstream proxies (hank-llm-arena) and UIs:

- `x-thinking-budget-applied` (existing)
- `x-thinking-budget-resolved` (NEW)
- `x-thinking-budget-source` (NEW)
- `x-thinking-budget-max-tokens-floor` (NEW)

Non-streaming `/v1/messages` responses now emit `type: "thinking"` content blocks before `type: "text"`, matching the streaming path and Anthropic's public API.

## Test plan

- [x] `tests/test_effort_resolver.py` — unit coverage for every precedence branch (27 tests)
- [x] `tests/test_anthropic_adapter_effort.py` — adapter integration (7 tests)
- [x] `tests/test_anthropic_adapter_thinking_block.py` — non-streaming thinking block emission (4 tests)
- [x] `tests/test_openai_reasoning_effort.py` — OpenAI schema (3 tests)
- [x] `tests/test_cache_endpoints.py` — cache clear + stats (4 tests)
- [x] `tests/test_thinking_budget_headers.py` — header emission (4 tests)
- [x] `tests/test_thinking_budget_matrix.py` — HTTP matrix extended with 9 new parametrized rows (integration tests, require `$THINKING_BUDGET_MATRIX` env var)
- [x] Pre-existing async-related failures in `test_batching*.py` etc. are unrelated to this PR (confirmed against base main)

## Documentation

- `docs/guides/effort-and-budget.md` — user-facing reference for every knob + precedence + per-family enforceability.
- `UPSTREAM_PIN.md` — three new invariants to protect the contract against upstream merge regressions.

## Known follow-ups

1. Move `_MIN_CONTENT_HEADROOM` guardrail below the resolver so `reasoning_effort`-derived budgets trigger the size warning.
2. Adapter-level test for `_PrefixCacheEndpointAdapter` (current tests mock at the `app.state` level, bypassing the adapter's attribute-walking logic).
3. WARN when `anthropic_thinking` is a non-empty dict missing `type` entirely.
4. `x-thinking-budget-signature` on thinking blocks (for clients that round-trip thinking blocks back into requests).
5. Plumb real `context_window` from engine config to both `resolve_effort` call sites (currently default 131072).

## Related

- hank-llm-arena companion PR: max_tokens auto-scaling in WS chat path + per-model "Clear cache" / "Restart" admin UI (separate spec/plan, blocked on this PR's header contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)