### PR TITLE
fix(anthropic): required signature field on thinking content blocks

### DIFF
--- a/UPSTREAM_PIN.md
+++ b/UPSTREAM_PIN.md
@@ -150,11 +150,13 @@ Downstream consumer assumption: `hank-llm-arena::proxy.py::_FORWARDED_HEADERS` f
 
 Test guard: `tests/test_thinking_budget_headers.py` + matrix rows in `tests/test_thinking_budget_matrix.py`.
 
-### Invariant 13: Non-streaming Anthropic thinking-block ordering
+### Invariant 13: Non-streaming Anthropic thinking-block ordering and schema
 
 `vllm_mlx.api.anthropic_adapter.openai_to_anthropic` MUST emit a `type: "thinking"` content block BEFORE the `type: "text"` content block when `choice.message.reasoning` is populated. The ordering matches Anthropic's public API and the streaming path (`server.py:1991-2032`).
 
-Test guard: `tests/test_anthropic_adapter_thinking_block.py`.
+Every `type: "thinking"` block MUST also be schema-conformant with the Anthropic SDK's `ThinkingBlock` model: it MUST include a `signature: str` field. We populate it with `"vllm-mlx:" + sha256(thinking_text).hexdigest()[:32]` — an opaque, deterministic hash so identical reasoning text produces identical signatures across requests. The prefix distinguishes our signatures from Anthropic's own server-signed values.
+
+Test guards: `tests/test_anthropic_adapter_thinking_block.py` (ordering), `tests/test_anthropic_thinking_block_schema.py` (signature contract).
 
 ## Rebase checklist
 

--- a/tests/test_anthropic_thinking_block_schema.py
+++ b/tests/test_anthropic_thinking_block_schema.py
@@ -1,0 +1,95 @@
+"""Anthropic SDK's ThinkingBlock model requires a `signature` field on
+every type:"thinking" content block. Our adapter must populate it with a
+deterministic, opaque string so same-text always produces same-signature.
+
+Contract: we emit `"vllm-mlx:" + sha256(thinking_text).hexdigest()[:32]`.
+The prefix distinguishes our signatures from Anthropic's own server-signed
+values, and the hex digest makes repeated requests on the same reasoning
+text stable (useful for caching/replay)."""
+
+import hashlib
+
+from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+from vllm_mlx.api.anthropic_models import AnthropicResponseContentBlock
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    Usage,
+)
+
+
+def _mk_openai_response(
+    *,
+    content: str | None = None,
+    reasoning: str | None = None,
+) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="test-id",
+        object="chat.completion",
+        created=0,
+        model="any-model",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=AssistantMessage(
+                    role="assistant",
+                    content=content,
+                    reasoning=reasoning,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+
+def test_content_block_model_accepts_signature_field():
+    """Schema: the Pydantic model has a `signature` field (str | None)."""
+    block = AnthropicResponseContentBlock(
+        type="thinking",
+        thinking="some reasoning",
+        signature="vllm-mlx:deadbeef",
+    )
+    assert block.signature == "vllm-mlx:deadbeef"
+
+
+def test_thinking_block_has_deterministic_signature():
+    """Signature must be populated on thinking blocks and must be a stable
+    function of the thinking text so identical reasoning → identical sig."""
+    text = "Let me think step by step about this problem..."
+    resp = _mk_openai_response(reasoning=text, content="42")
+
+    out = openai_to_anthropic(resp, model="any-model")
+
+    thinking_blocks = [b for b in out.content if b.type == "thinking"]
+    assert len(thinking_blocks) == 1
+    assert thinking_blocks[0].signature is not None
+
+    expected = "vllm-mlx:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:32]
+    assert thinking_blocks[0].signature == expected
+
+    # Stability: a second adapter call on the same reasoning text yields the
+    # same signature.
+    out2 = openai_to_anthropic(resp, model="any-model")
+    assert out2.content[0].signature == thinking_blocks[0].signature
+
+
+def test_non_thinking_blocks_have_no_signature():
+    """signature is only meaningful on thinking blocks; text/tool_use blocks
+    leave it as None (field exists but is unset)."""
+    resp = _mk_openai_response(reasoning="x", content="answer")
+    out = openai_to_anthropic(resp, model="any-model")
+
+    for block in out.content:
+        if block.type != "thinking":
+            assert block.signature is None, (
+                f"{block.type} block should not have a signature"
+            )
+
+
+def test_different_reasoning_produces_different_signatures():
+    """Sanity: the hash is not a constant."""
+    r1 = openai_to_anthropic(_mk_openai_response(reasoning="one"), model="m")
+    r2 = openai_to_anthropic(_mk_openai_response(reasoning="two"), model="m")
+    assert r1.content[0].signature != r2.content[0].signature

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -8,6 +8,7 @@ Handles translation of:
 - Messages: Content blocks, tool calls, tool results
 """
 
+import hashlib
 import json
 import uuid
 
@@ -139,10 +140,17 @@ def openai_to_anthropic(
         # Matches Anthropic's public API and the streaming path
         # (server.py:1991-2032).
         if choice.message.reasoning:
+            sig = (
+                "vllm-mlx:"
+                + hashlib.sha256(
+                    choice.message.reasoning.encode("utf-8")
+                ).hexdigest()[:32]
+            )
             content.append(
                 AnthropicResponseContentBlock(
                     type="thinking",
                     thinking=choice.message.reasoning,
+                    signature=sig,
                 )
             )
 

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -106,6 +106,10 @@ class AnthropicResponseContentBlock(BaseModel):
     # attached reasoning parser's extracted <think>...</think> span.
     # Distinct from text so clients can segment reasoning from the answer.
     thinking: str | None = None
+    # Required by Anthropic SDK's ThinkingBlock schema: an opaque signature
+    # string clients can use to verify/echo the thinking block. We emit a
+    # deterministic hash of the thinking text so same-text → same-signature.
+    signature: str | None = None
     # tool_use fields
     id: str | None = None
     name: str | None = None


### PR DESCRIPTION
## Summary

- Add required `signature` field to `AnthropicResponseContentBlock` so our non-streaming `/v1/messages` response is schema-conformant with the Anthropic SDK's `ThinkingBlock` model
- Populate signature deterministically: `"vllm-mlx:" + sha256(thinking_text).hexdigest()[:32]` — same reasoning text → same signature across requests
- Upgrade UPSTREAM_PIN invariant #13 to include the schema-conformance requirement

## Why this matters

Clients using the typed Anthropic SDK (e.g., `anthropic.types.ThinkingBlock`) currently reject our response because `signature` is a required field on thinking blocks per Anthropic's public API. Adding the field unblocks those clients. Same-text → same-signature makes the field useful for replay caching without leaking server-side state.

## Scope

Non-streaming only. The streaming path (`_emit_content_pieces` in `server.py:2180-2230`) still omits signature; a follow-up will emit it as `signature_delta` at block close. Tracked as a known gap.

## Context

This was extracted from the PR #13 follow-up fix plan as a standalone, low-risk change. The full multi-PR follow-up plan (cache safety + resolver hardening + observability + test coverage) lives at `docs/superpowers/plans/2026-04-19-pr13-followup-fixes-v2.md` and will ship as separate PRs.

## Test plan
- [x] Unit tests: `tests/test_anthropic_thinking_block_schema.py` — 4 tests, all pass
- [x] Existing thinking-block tests still pass: `tests/test_anthropic_adapter_thinking_block.py` — 4/4
- [x] Full unit suite: 1235 pass, 26 pre-existing async-plugin failures unrelated to this change
- [ ] Manual: hit `/v1/messages` with a reasoning model, verify `signature` present on thinking blocks in response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)