### PR TITLE
feat(server): noop-reason header + floor WARN + merge plumbing

### DIFF
--- a/UPSTREAM_PIN.md
+++ b/UPSTREAM_PIN.md
@@ -138,15 +138,16 @@ Adding a new provider dialect means extending `EffortSource` + the resolver. It 
 
 Test guard: `tests/test_effort_resolver.py` + `tests/test_anthropic_adapter_effort.py`.
 
-### Invariant 12: Four-header contract on budget-resolved responses
+### Invariant 12: Five-header contract on budget-resolved responses
 
 Every chat-completion or messages response that went through the resolver MUST emit:
 - `x-thinking-budget-applied` (`true` | `false`, absent when no budget requested)
 - `x-thinking-budget-resolved` (int as string, or `"none"`)
 - `x-thinking-budget-source` (one of the `EffortSource` enum values)
 - `x-thinking-budget-max-tokens-floor` (int as string, absent when source=default or budget=0)
+- `x-thinking-budget-noop-reason` (string; emitted ONLY when `applied=false`; one of `parser_not_configured` / `tokenizer_encode_failed` / `multi_token_delimiter` / `mllm_path` / `simple_engine`)
 
-Downstream consumer assumption: `hank-llm-arena::proxy.py::_FORWARDED_HEADERS` forwards the `x-thinking-` prefix to clients. Arena's admin UI reads these headers to show a per-request "effort honored" indicator.
+Downstream consumer assumption: `hank-llm-arena::proxy.py::_FORWARDED_HEADERS` forwards the `x-thinking-` prefix to clients. Arena's admin UI reads these headers to show a per-request "effort honored" indicator. The `noop-reason` header is what operators use to diagnose why the feature is a no-op (e.g., `simple_engine` means the server needs `--continuous-batching`).
 
 Test guard: `tests/test_thinking_budget_headers.py` + matrix rows in `tests/test_thinking_budget_matrix.py`.
 

--- a/tests/test_output_collector.py
+++ b/tests/test_output_collector.py
@@ -1,0 +1,45 @@
+"""Pinning test for _merge_outputs's noop_reason rule.
+
+When merging two outputs, prefer non-None for thinking_budget_noop_reason so
+that a mid-stream marker (set by the happy-path scheduler/engine) survives a
+later abort/error output that carries None in the field.
+"""
+
+from vllm_mlx.output_collector import RequestOutputCollector
+from vllm_mlx.request import RequestOutput
+
+
+def _mk_output(noop_reason, applied=None):
+    # Construct with only the fields _merge_outputs actually reads.
+    # Use defaults for everything else; the collector's own tests are
+    # source of truth on the full signature.
+    return RequestOutput(
+        request_id="req-1",
+        new_token_ids=[],
+        new_text="",
+        output_token_ids=[],
+        prompt_tokens=0,
+        completion_tokens=0,
+        thinking_budget_applied=applied,
+        thinking_budget_noop_reason=noop_reason,
+    )
+
+
+def test_merge_outputs_preserves_noop_reason_through_abort():
+    """Mid-stream noop_reason must survive a later None-carrying abort."""
+    collector = RequestOutputCollector()
+    mid = _mk_output(noop_reason="mllm_path", applied=False)
+    abort = _mk_output(noop_reason=None, applied=None)
+
+    merged = collector._merge_outputs(mid, abort)
+    assert merged.thinking_budget_noop_reason == "mllm_path"
+
+
+def test_merge_outputs_later_non_none_overwrites_earlier_none():
+    """A later populated noop_reason replaces a prior None."""
+    collector = RequestOutputCollector()
+    early = _mk_output(noop_reason=None, applied=None)
+    later = _mk_output(noop_reason="simple_engine", applied=False)
+
+    merged = collector._merge_outputs(early, later)
+    assert merged.thinking_budget_noop_reason == "simple_engine"

--- a/tests/test_simple_engine_noop_reason.py
+++ b/tests/test_simple_engine_noop_reason.py
@@ -1,0 +1,63 @@
+"""Smoke test: SimpleEngine paths set thinking_budget_noop_reason='simple_engine'
+on GenerationOutput when thinking_token_budget was requested but can't be enforced.
+
+This is a unit-level pin -- not an integration test. We construct a minimal
+GenerationOutput and verify the fields flow through correctly. Paired with the
+fix that propagates _tb_* kwargs through _stream_generate_specprefill and
+_stream_generate_text so the markers survive the inner-helper yields.
+"""
+from vllm_mlx.engine.base import GenerationOutput
+
+
+def test_generation_output_carries_simple_engine_reason():
+    """GenerationOutput accepts and stores thinking_budget_noop_reason='simple_engine'."""
+    out = GenerationOutput(
+        text="hi",
+        tokens=[1, 2],
+        finish_reason="stop",
+        thinking_budget_applied=False,
+        thinking_budget_noop_reason="simple_engine",
+    )
+    assert out.thinking_budget_applied is False
+    assert out.thinking_budget_noop_reason == "simple_engine"
+
+
+def test_generation_output_carries_mllm_path_reason():
+    """GenerationOutput accepts and stores thinking_budget_noop_reason='mllm_path'."""
+    out = GenerationOutput(
+        text="hi",
+        tokens=[1, 2],
+        finish_reason="stop",
+        thinking_budget_applied=False,
+        thinking_budget_noop_reason="mllm_path",
+    )
+    assert out.thinking_budget_noop_reason == "mllm_path"
+
+
+def test_generation_output_default_noop_reason_is_none():
+    """When no thinking budget was requested, both fields default to None."""
+    out = GenerationOutput(text="hi", tokens=[1])
+    assert out.thinking_budget_applied is None
+    assert out.thinking_budget_noop_reason is None
+
+
+def test_stream_generate_specprefill_accepts_tb_kwargs():
+    """_stream_generate_specprefill signature accepts tb_applied / tb_noop_reason."""
+    import inspect
+
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    sig = inspect.signature(SimpleEngine._stream_generate_specprefill)
+    assert "tb_applied" in sig.parameters
+    assert "tb_noop_reason" in sig.parameters
+
+
+def test_stream_generate_text_accepts_tb_kwargs():
+    """_stream_generate_text signature accepts tb_applied / tb_noop_reason."""
+    import inspect
+
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    sig = inspect.signature(SimpleEngine._stream_generate_text)
+    assert "tb_applied" in sig.parameters
+    assert "tb_noop_reason" in sig.parameters

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -260,28 +260,38 @@ class TestAttachProcessor:
             prompt_token_ids=None,
         )
         base.update(overrides)
+        # Helper now returns (processor_or_None, reason_or_None) (PR-D D.2).
         return _attach_thinking_budget_processor(**base)
 
     def test_returns_processor_when_valid(self):
-        proc = self._call()
+        proc, reason = self._call()
         assert proc is not None
+        assert reason is None
 
     def test_none_when_budget_is_none(self):
-        assert self._call(budget=None) is None
+        # budget=None is NOT a no-op — reason must be None, not a string.
+        proc, reason = self._call(budget=None)
+        assert proc is None
+        assert reason is None
 
     def test_none_when_no_parser(self):
-        assert self._call(reasoning_parser=None) is None
+        proc, reason = self._call(reasoning_parser=None)
+        assert proc is None
+        assert reason == "parser_not_configured"
 
     def test_none_when_start_tokenize_fails(self):
         class BrokenTok:
             def encode(self, text, add_special_tokens=False):
                 raise RuntimeError("oops")
 
-        assert self._call(tokenizer=BrokenTok()) is None
+        proc, reason = self._call(tokenizer=BrokenTok())
+        assert proc is None
+        assert reason == "tokenizer_encode_failed"
 
     def test_message_tokenized_when_provided(self):
-        proc = self._call(message="Wrap it up.")
+        proc, reason = self._call(message="Wrap it up.")
         assert proc is not None
+        assert reason is None
         # Force sequence includes message ids (50, 51) then end ids (200).
         assert proc._force_sequence == [50, 51, 200]
 

--- a/tests/test_thinking_budget_headers.py
+++ b/tests/test_thinking_budget_headers.py
@@ -64,3 +64,47 @@ def test_helper_zero_budget_omits_floor():
     headers = _build_thinking_budget_headers(resolved, applied=True)
     assert headers["x-thinking-budget-resolved"] == "0"
     assert "x-thinking-budget-max-tokens-floor" not in headers
+
+
+def test_noop_reason_emitted_when_applied_false():
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=512,
+        source=EffortSource.TOP_LEVEL,
+        max_tokens_floor=2048,
+        effort_label=None,
+    )
+    headers = _build_thinking_budget_headers(
+        resolved, applied=False, noop_reason="mllm_path",
+    )
+    assert headers["x-thinking-budget-applied"] == "false"
+    assert headers["x-thinking-budget-noop-reason"] == "mllm_path"
+
+
+def test_noop_reason_omitted_when_applied_true():
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=512,
+        source=EffortSource.TOP_LEVEL,
+        max_tokens_floor=2048,
+        effort_label=None,
+    )
+    headers = _build_thinking_budget_headers(resolved, applied=True)
+    assert "x-thinking-budget-noop-reason" not in headers
+
+
+def test_noop_reason_omitted_when_none_even_on_false():
+    from vllm_mlx.server import _build_thinking_budget_headers
+
+    resolved = ResolvedBudget(
+        budget=512,
+        source=EffortSource.TOP_LEVEL,
+        max_tokens_floor=2048,
+        effort_label=None,
+    )
+    headers = _build_thinking_budget_headers(
+        resolved, applied=False, noop_reason=None,
+    )
+    assert "x-thinking-budget-noop-reason" not in headers

--- a/tests/test_thinking_budget_headers.py
+++ b/tests/test_thinking_budget_headers.py
@@ -108,3 +108,41 @@ def test_noop_reason_omitted_when_none_even_on_false():
         resolved, applied=False, noop_reason=None,
     )
     assert "x-thinking-budget-noop-reason" not in headers
+
+
+def test_warn_when_max_tokens_below_floor(caplog):
+    """When client sets max_tokens < resolver's max_tokens_floor, log a WARN
+    so operators can diagnose the truncation mistake. Sibling of PR #12's
+    WARN (max_tokens <= budget)."""
+    import logging
+    from vllm_mlx.server import _warn_if_max_tokens_below_floor
+    from vllm_mlx.api.effort import EffortSource, ResolvedBudget
+
+    resolved = ResolvedBudget(
+        budget=8192,
+        source=EffortSource.REASONING_EFFORT,
+        max_tokens_floor=16384,
+        effort_label="high",
+    )
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.server"):
+        _warn_if_max_tokens_below_floor(resolved, max_tokens=4000)
+    msgs = [r.message for r in caplog.records]
+    assert any(
+        "[thinking-budget-resolver]" in m
+        and "4000" in m and "16384" in m
+        for m in msgs
+    )
+
+
+def test_no_warn_when_max_tokens_meets_floor(caplog):
+    import logging
+    from vllm_mlx.server import _warn_if_max_tokens_below_floor
+    from vllm_mlx.api.effort import EffortSource, ResolvedBudget
+
+    resolved = ResolvedBudget(
+        budget=8192, source=EffortSource.REASONING_EFFORT,
+        max_tokens_floor=16384, effort_label="high",
+    )
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.server"):
+        _warn_if_max_tokens_below_floor(resolved, max_tokens=20000)
+    assert not caplog.records

--- a/tests/test_thinking_budget_rebase_sentinel.py
+++ b/tests/test_thinking_budget_rebase_sentinel.py
@@ -256,7 +256,7 @@ class TestThinkingBudgetSentinel:
 
         from vllm_mlx.scheduler import _attach_thinking_budget_processor
 
-        proc = _attach_thinking_budget_processor(
+        proc, reason = _attach_thinking_budget_processor(
             tokenizer=_FakeTok(),
             reasoning_parser=_FakeParser(),
             budget=512,
@@ -264,6 +264,7 @@ class TestThinkingBudgetSentinel:
             prompt_token_ids=None,
         )
         assert isinstance(proc, ThinkingTokenBudgetLogitsProcessor)
+        assert reason is None
 
     def test_scheduler_output_propagates_applied(self):
         """Pin the CRITICAL-1 fix: scheduler's _process_batch_responses must
@@ -350,7 +351,7 @@ class TestThinkingBudgetSentinel:
             start_token = "<think>"
             end_tokens = ["</think>"]
 
-        proc = _attach_thinking_budget_processor(
+        proc, reason = _attach_thinking_budget_processor(
             tokenizer=_OversizeTok(),
             reasoning_parser=_FakeParser(),
             budget=512,
@@ -358,6 +359,7 @@ class TestThinkingBudgetSentinel:
             prompt_token_ids=None,
         )
         assert isinstance(proc, ThinkingTokenBudgetLogitsProcessor)
+        assert reason is None
         # Force sequence must be end_token_ids only — the oversized
         # message was dropped. If the cap check regresses, the sequence
         # would be 1000..1549+[200] = 551 tokens.

--- a/tests/test_thinking_budget_rebase_sentinel.py
+++ b/tests/test_thinking_budget_rebase_sentinel.py
@@ -73,12 +73,23 @@ class TestThinkingBudgetSentinel:
         assert "thinking_budget_noop_reason" in Request.__dataclass_fields__, (
             "Request.thinking_budget_noop_reason removed — rebase regression"
         )
+        f = Request.__dataclass_fields__["thinking_budget_noop_reason"]
+        assert f.default is None, (
+            "Default for thinking_budget_noop_reason changed; "
+            "header emission depends on None sentinel."
+        )
 
     def test_rebase_sentinel_noop_reason_field_on_request_output(self):
+        """noop_reason field on RequestOutput is pinned to survive rebase."""
         from vllm_mlx.request import RequestOutput
 
         assert "thinking_budget_noop_reason" in RequestOutput.__dataclass_fields__, (
             "RequestOutput.thinking_budget_noop_reason removed — rebase regression"
+        )
+        f = RequestOutput.__dataclass_fields__["thinking_budget_noop_reason"]
+        assert f.default is None, (
+            "Default for thinking_budget_noop_reason changed; "
+            "header emission depends on None sentinel."
         )
 
     def test_generation_output_has_applied_field(self):

--- a/tests/test_thinking_budget_rebase_sentinel.py
+++ b/tests/test_thinking_budget_rebase_sentinel.py
@@ -65,6 +65,22 @@ class TestThinkingBudgetSentinel:
         ro = RequestOutput(request_id="x")
         assert hasattr(ro, "thinking_budget_applied")
 
+    def test_rebase_sentinel_noop_reason_field_on_request(self):
+        """noop_reason field on Request is pinned to survive rebase."""
+        from vllm_mlx.request import Request
+
+        assert hasattr(Request, "__dataclass_fields__")
+        assert "thinking_budget_noop_reason" in Request.__dataclass_fields__, (
+            "Request.thinking_budget_noop_reason removed — rebase regression"
+        )
+
+    def test_rebase_sentinel_noop_reason_field_on_request_output(self):
+        from vllm_mlx.request import RequestOutput
+
+        assert "thinking_budget_noop_reason" in RequestOutput.__dataclass_fields__, (
+            "RequestOutput.thinking_budget_noop_reason removed — rebase regression"
+        )
+
     def test_generation_output_has_applied_field(self):
         """Pin the api-surface dataclass: server.py reads
         GenerationOutput.thinking_budget_applied via getattr(..., None).

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -29,6 +29,12 @@ class GenerationOutput:
     # MLLM branch; read by server.py to emit x-thinking-budget-applied
     # response header). None when no budget was requested.
     thinking_budget_applied: bool | None = None
+    # Machine-readable reason when thinking_budget_applied is False.
+    # Populated by the MLLM path (``"mllm_path"``), SimpleEngine
+    # (``"simple_engine"``), or propagated from the scheduler's
+    # Request.thinking_budget_noop_reason via RequestOutput (Task D.3+).
+    # None when thinking_budget_applied is True or None.
+    thinking_budget_noop_reason: str | None = None
 
 
 class BaseEngine(ABC):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -187,16 +187,20 @@ class BatchedEngine(BaseEngine):
 
     def _log_mllm_budget_noop(
         self, thinking_token_budget: int | None, method: str
-    ) -> bool | None:
+    ) -> tuple[bool | None, str | None]:
         """Log WARN + increment noop counter when a thinking-token-budget
         was requested on the MLLM path (which does not enforce it yet).
 
-        Returns the value that should be written to
-        ``GenerationOutput.thinking_budget_applied`` (False if a budget was
-        requested, None otherwise).
+        Returns ``(applied, noop_reason)`` where:
+          - ``applied`` is the value that should be written to
+            ``GenerationOutput.thinking_budget_applied`` (False if a budget
+            was requested, None otherwise).
+          - ``noop_reason`` is ``"mllm_path"`` when applied is False, else
+            None. Propagated to ``GenerationOutput.thinking_budget_noop_reason``
+            by call sites.
         """
         if thinking_token_budget is None:
-            return None
+            return None, None
         logger.warning(
             "BatchedEngine.%s: thinking_token_budget=%s requested for an "
             "MLLM request, but the MLLM path does not yet support it. "
@@ -212,7 +216,7 @@ class BatchedEngine(BaseEngine):
         except ImportError:
             # Task 6 creates vllm_mlx.metrics; tolerate its absence.
             pass
-        return False
+        return False, "mllm_path"
 
     async def start(self) -> None:
         """Start the engine (load model if not loaded)."""
@@ -528,7 +532,7 @@ class BatchedEngine(BaseEngine):
             # Use MLLM scheduler for all requests when model is multimodal.
             # MLLM models only initialise the _mllm_scheduler (not _engine),
             # so text-only requests must also be routed here.
-            tb_applied = self._log_mllm_budget_noop(
+            tb_applied, tb_noop_reason = self._log_mllm_budget_noop(
                 thinking_token_budget, "generate"
             )
             output = await self._mllm_scheduler.generate(
@@ -546,6 +550,7 @@ class BatchedEngine(BaseEngine):
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,
                 thinking_budget_applied=tb_applied,
+                thinking_budget_noop_reason=tb_noop_reason,
             )
 
         # Use LLM engine for text-only (non-MLLM models)
@@ -576,6 +581,9 @@ class BatchedEngine(BaseEngine):
             # x-thinking-budget-applied correctly. None when no budget
             # was requested; True/False otherwise.
             thinking_budget_applied=output.thinking_budget_applied,
+            thinking_budget_noop_reason=getattr(
+                output, "thinking_budget_noop_reason", None
+            ),
         )
 
     async def stream_generate(
@@ -615,7 +623,7 @@ class BatchedEngine(BaseEngine):
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
-            tb_applied = self._log_mllm_budget_noop(
+            tb_applied, tb_noop_reason = self._log_mllm_budget_noop(
                 thinking_token_budget, "stream_generate"
             )
             request_id = await self._mllm_scheduler.add_request_async(
@@ -636,6 +644,7 @@ class BatchedEngine(BaseEngine):
                     finished=output.finished,
                     finish_reason=output.finish_reason,
                     thinking_budget_applied=tb_applied,
+                    thinking_budget_noop_reason=tb_noop_reason,
                 )
             return
 
@@ -669,6 +678,9 @@ class BatchedEngine(BaseEngine):
                 finished=output.finished,
                 finish_reason=output.finish_reason,
                 thinking_budget_applied=output.thinking_budget_applied,
+                thinking_budget_noop_reason=getattr(
+                    output, "thinking_budget_noop_reason", None
+                ),
             )
 
     async def chat(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -269,6 +269,8 @@ class SimpleEngine(BaseEngine):
         # SimpleEngine wraps mlx_lm.generate directly — the thinking-budget
         # logits processor is only installed by the Scheduler (BatchedEngine
         # text branch). Accept the kwargs for API symmetry but warn when set.
+        _tb_applied: bool | None = None
+        _tb_noop_reason: str | None = None
         if thinking_token_budget is not None:
             logger.warning(
                 "SimpleEngine.generate: thinking_token_budget=%s ignored in simple mode. "
@@ -281,6 +283,8 @@ class SimpleEngine(BaseEngine):
                 thinking_budget_noop_total.inc()
             except ImportError:
                 pass
+            _tb_applied = False
+            _tb_noop_reason = "simple_engine"
 
         async with self._generation_lock:
             # Run in thread pool to allow asyncio timeout to work
@@ -305,6 +309,8 @@ class SimpleEngine(BaseEngine):
                     output, "completion_tokens", len(getattr(output, "tokens", []))
                 ),
                 finish_reason=output.finish_reason,
+                thinking_budget_applied=_tb_applied,
+                thinking_budget_noop_reason=_tb_noop_reason,
             )
 
     async def stream_generate(
@@ -339,6 +345,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        _tb_applied: bool | None = None
+        _tb_noop_reason: str | None = None
         if thinking_token_budget is not None:
             logger.warning(
                 "SimpleEngine.stream_generate: thinking_token_budget=%s ignored in simple mode. "
@@ -351,6 +359,8 @@ class SimpleEngine(BaseEngine):
                 thinking_budget_noop_total.inc()
             except ImportError:
                 pass
+            _tb_applied = False
+            _tb_noop_reason = "simple_engine"
 
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
@@ -439,6 +449,8 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=completion_tokens,
                     finished=finished,
                     finish_reason=finish_reason,
+                    thinking_budget_applied=_tb_applied,
+                    thinking_budget_noop_reason=_tb_noop_reason,
                 )
 
                 if finished:
@@ -454,6 +466,8 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=completion_tokens,
                     finished=True,
                     finish_reason=None,
+                    thinking_budget_applied=_tb_applied,
+                    thinking_budget_noop_reason=_tb_noop_reason,
                 )
 
     async def chat(
@@ -491,6 +505,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        _tb_applied: bool | None = None
+        _tb_noop_reason: str | None = None
         if thinking_token_budget is not None:
             logger.warning(
                 "SimpleEngine.chat: thinking_token_budget=%s ignored in simple mode. "
@@ -503,6 +519,8 @@ class SimpleEngine(BaseEngine):
                 thinking_budget_noop_total.inc()
             except ImportError:
                 pass
+            _tb_applied = False
+            _tb_noop_reason = "simple_engine"
 
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -525,6 +543,8 @@ class SimpleEngine(BaseEngine):
                     prompt_tokens=output.prompt_tokens,
                     completion_tokens=output.completion_tokens,
                     finish_reason=output.finish_reason,
+                    thinking_budget_applied=_tb_applied,
+                    thinking_budget_noop_reason=_tb_noop_reason,
                 )
             else:
                 # For LLM, use the chat method
@@ -561,6 +581,8 @@ class SimpleEngine(BaseEngine):
                     prompt_tokens=prompt_token_count,
                     completion_tokens=len(output.tokens),
                     finish_reason=output.finish_reason,
+                    thinking_budget_applied=_tb_applied,
+                    thinking_budget_noop_reason=_tb_noop_reason,
                 )
 
     async def stream_chat(
@@ -598,6 +620,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        _tb_applied: bool | None = None
+        _tb_noop_reason: str | None = None
         if thinking_token_budget is not None:
             logger.warning(
                 "SimpleEngine.stream_chat: thinking_token_budget=%s ignored in simple mode. "
@@ -610,6 +634,8 @@ class SimpleEngine(BaseEngine):
                 thinking_budget_noop_total.inc()
             except ImportError:
                 pass
+            _tb_applied = False
+            _tb_noop_reason = "simple_engine"
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -671,6 +697,8 @@ class SimpleEngine(BaseEngine):
                         completion_tokens=token_count,
                         finished=finished,
                         finish_reason=chunk.finish_reason if finished else None,
+                        thinking_budget_applied=_tb_applied,
+                        thinking_budget_noop_reason=_tb_noop_reason,
                     )
 
                     if finished:
@@ -713,7 +741,10 @@ class SimpleEngine(BaseEngine):
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
             prompt += "\nassistant:"
 
-        # Stream generate
+        # Stream generate — propagate the noop markers this method already
+        # emitted the WARN for. We intentionally do NOT forward
+        # thinking_token_budget to avoid a duplicate WARN / duplicate metric
+        # bump inside stream_generate.
         async for output in self.stream_generate(
             prompt=prompt,
             max_tokens=max_tokens,
@@ -721,6 +752,9 @@ class SimpleEngine(BaseEngine):
             top_p=top_p,
             **kwargs,
         ):
+            if _tb_applied is False:
+                output.thinking_budget_applied = _tb_applied
+                output.thinking_budget_noop_reason = _tb_noop_reason
             yield output
 
     async def _stream_generate_specprefill(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -407,6 +407,8 @@ class SimpleEngine(BaseEngine):
                         top_p,
                         stop=stop,
                         specprefill_keep_pct=specprefill_keep_pct_override,
+                        tb_applied=_tb_applied,
+                        tb_noop_reason=_tb_noop_reason,
                         **kwargs,
                     ):
                         yield output
@@ -653,6 +655,8 @@ class SimpleEngine(BaseEngine):
                 temperature,
                 top_p,
                 tools=template_tools,
+                tb_applied=_tb_applied,
+                tb_noop_reason=_tb_noop_reason,
                 **kwargs,
             ):
                 yield chunk
@@ -766,6 +770,8 @@ class SimpleEngine(BaseEngine):
         top_p: float,
         stop: list[str] | None = None,
         specprefill_keep_pct: float | None = None,
+        tb_applied: bool | None = None,
+        tb_noop_reason: str | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """SpecPrefill path for non-MTP models (Nemotron, GPT-OSS, etc).
@@ -925,6 +931,8 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=finished,
                 finish_reason=resp.finish_reason or ("stop" if finished else None),
+                thinking_budget_applied=tb_applied,
+                thinking_budget_noop_reason=tb_noop_reason,
             )
 
             if finished:
@@ -938,6 +946,8 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=True,
                 finish_reason="length",
+                thinking_budget_applied=tb_applied,
+                thinking_budget_noop_reason=tb_noop_reason,
             )
 
     async def _stream_generate_text(
@@ -947,6 +957,8 @@ class SimpleEngine(BaseEngine):
         temperature: float,
         top_p: float,
         tools: list | None = None,
+        tb_applied: bool | None = None,
+        tb_noop_reason: str | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """Text-only generation via mlx_lm TextModel with MTP.
@@ -1354,6 +1366,8 @@ class SimpleEngine(BaseEngine):
                 finished=finished,
                 finish_reason=getattr(resp, "finish_reason", None)
                 or ("stop" if finished else None),
+                thinking_budget_applied=tb_applied,
+                thinking_budget_noop_reason=tb_noop_reason,
             )
 
             if finished:
@@ -1367,6 +1381,8 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=True,
                 finish_reason="length",
+                thinking_budget_applied=tb_applied,
+                thinking_budget_noop_reason=tb_noop_reason,
             )
 
     def get_stats(self) -> dict[str, Any]:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -514,6 +514,19 @@ class MLLMScheduler:
                 new_text = detok.last_segment
 
             # Create output
+            # MLLM scheduler path cannot enforce thinking_token_budget
+            # (no logits-processor hook on the MLLM batched generate path).
+            # Mirror engine/batched.py::_log_mllm_budget_noop by surfacing
+            # applied=False + noop_reason="mllm_path" whenever a budget was
+            # requested, so the server emits the honest
+            # x-thinking-budget-applied=false + x-thinking-budget-noop-reason
+            # headers. When no budget was requested, leave both fields as
+            # None.
+            _tb_budget = (
+                request.sampling_params.thinking_token_budget
+                if request.sampling_params
+                else None
+            )
             output = RequestOutput(
                 request_id=request_id,
                 new_token_ids=[response.token],
@@ -521,6 +534,10 @@ class MLLMScheduler:
                 output_token_ids=list(request.output_tokens),
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                thinking_budget_applied=False if _tb_budget is not None else None,
+                thinking_budget_noop_reason=(
+                    "mllm_path" if _tb_budget is not None else None
+                ),
             )
 
             # Check if finished
@@ -802,12 +819,27 @@ class MLLMScheduler:
                 break
 
         if final_output is None:
-            # Create empty output on error
+            # Create empty output on error. Carry the honest thinking-
+            # budget signal: if the request had a budget set, report it
+            # as a no-op with reason "mllm_path" (the MLLM scheduler path
+            # cannot enforce logits-processor-based budgets). Otherwise
+            # leave both fields as None. See sibling site in
+            # _process_batch_responses and engine/batched.py::_log_mllm_budget_noop.
+            _err_req = self.requests.get(request_id)
+            _tb_budget = (
+                _err_req.sampling_params.thinking_token_budget
+                if _err_req is not None and _err_req.sampling_params
+                else None
+            )
             final_output = RequestOutput(
                 request_id=request_id,
                 output_text="",
                 finished=True,
                 finish_reason="error",
+                thinking_budget_applied=False if _tb_budget is not None else None,
+                thinking_budget_noop_reason=(
+                    "mllm_path" if _tb_budget is not None else None
+                ),
             )
 
         # Cleanup

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -159,6 +159,14 @@ class RequestOutputCollector:
                 if new.thinking_budget_applied is not None
                 else existing.thinking_budget_applied
             ),
+            # Same prefer-non-None rule for the noop reason so a mid-stream
+            # "mllm_path" marker isn't overwritten by a later None-carrying
+            # error/abort output.
+            thinking_budget_noop_reason=(
+                new.thinking_budget_noop_reason
+                if new.thinking_budget_noop_reason is not None
+                else existing.thinking_budget_noop_reason
+            ),
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -159,6 +159,16 @@ class Request:
     #           x-thinking-budget-applied response header (Task 5).
     thinking_budget_applied: Optional[bool] = None
 
+    # Machine-readable reason when thinking_budget_applied is False.
+    # Values:
+    #   - "parser_not_configured"    — server started without --reasoning-parser
+    #   - "tokenizer_encode_failed"  — start/end delimiter encode raised
+    #   - "multi_token_delimiter"    — start/end delimiters not single-token
+    #   - "mllm_path"                — MLLM engine ignores logits_processors
+    #   - "simple_engine"            — SimpleEngine requires --continuous-batching
+    # None when thinking_budget_applied is True or None.
+    thinking_budget_noop_reason: Optional[str] = None
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""
@@ -236,6 +246,16 @@ class RequestOutput:
     #   None  = no budget requested. Server reads this to emit the
     #           x-thinking-budget-applied response header.
     thinking_budget_applied: Optional[bool] = None
+
+    # Machine-readable reason when thinking_budget_applied is False.
+    # Values:
+    #   - "parser_not_configured"    — server started without --reasoning-parser
+    #   - "tokenizer_encode_failed"  — start/end delimiter encode raised
+    #   - "multi_token_delimiter"    — start/end delimiters not single-token
+    #   - "mllm_path"                — MLLM engine ignores logits_processors
+    #   - "simple_engine"            — SimpleEngine requires --continuous-batching
+    # None when thinking_budget_applied is True or None.
+    thinking_budget_noop_reason: Optional[str] = None
 
     @property
     def usage(self) -> Dict[str, int]:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -165,7 +165,7 @@ class Request:
     #   - "tokenizer_encode_failed"  — start/end delimiter encode raised
     #   - "multi_token_delimiter"    — start/end delimiters not single-token
     #   - "mllm_path"                — MLLM engine ignores logits_processors
-    #   - "simple_engine"            — SimpleEngine requires --continuous-batching
+    #   - "simple_engine"            — SimpleEngine path does not run logits_processors (start server with --continuous-batching to enforce)
     # None when thinking_budget_applied is True or None.
     thinking_budget_noop_reason: Optional[str] = None
 
@@ -253,7 +253,7 @@ class RequestOutput:
     #   - "tokenizer_encode_failed"  — start/end delimiter encode raised
     #   - "multi_token_delimiter"    — start/end delimiters not single-token
     #   - "mllm_path"                — MLLM engine ignores logits_processors
-    #   - "simple_engine"            — SimpleEngine requires --continuous-batching
+    #   - "simple_engine"            — SimpleEngine path does not run logits_processors (start server with --continuous-batching to enforce)
     # None when thinking_budget_applied is True or None.
     thinking_budget_noop_reason: Optional[str] = None
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -120,18 +120,28 @@ def _attach_thinking_budget_processor(
 ):
     """Construct a ThinkingTokenBudgetLogitsProcessor for a single request.
 
-    Returns None (a loud no-op — caller should log WARN and increment the
-    metric) when any of:
-      - budget is None
-      - reasoning_parser is None (no --reasoning-parser flag)
-      - tokenizer can't encode the start/end delimiters to a non-empty list
+    Returns a 2-tuple ``(processor_or_None, reason_or_None)``:
 
-    Returns the processor on success.
+    - On success: ``(processor, None)``.
+    - On "not a no-op" (``budget is None``, i.e. the caller didn't ask for
+      a budget at all): ``(None, None)`` — caller should treat as a no-op
+      only if ``budget is not None``.
+    - On no-op (budget requested but processor can't be attached): ``(None,
+      "<reason>")``. Reason strings match ``Request.thinking_budget_noop_reason``:
+        - ``"parser_not_configured"``  — no reasoning parser configured
+        - ``"tokenizer_encode_failed"`` — tokenizer.encode raised or
+          returned empty/non-list for start or end delimiter
+        - ``"multi_token_delimiter"``  — (reserved for future use; no
+          length check in current code — see PR-D D.2 deviation note)
+
+    The caller is expected to log WARN and increment the noop counter when
+    the first element is None AND budget was requested.
     """
     if budget is None:
-        return None
+        # Budget wasn't requested — NOT a no-op.
+        return None, None
     if reasoning_parser is None:
-        return None
+        return None, "parser_not_configured"
 
     start_str = getattr(reasoning_parser, "start_token", "<think>")
     end_candidates = getattr(reasoning_parser, "end_tokens", ["</think>"])
@@ -150,7 +160,11 @@ def _attach_thinking_budget_processor(
 
     start_ids = _encode(start_str)
     if start_ids is None:
-        return None
+        # _encode returns None for BOTH exception and empty/non-list cases.
+        # Both are surfaced as tokenizer_encode_failed; we can't distinguish
+        # without adding a second return-value channel to _encode, which is
+        # out of scope for D.2.
+        return None, "tokenizer_encode_failed"
 
     end_ids = None
     for candidate in end_candidates:
@@ -159,7 +173,7 @@ def _attach_thinking_budget_processor(
             end_ids = enc
             break
     if end_ids is None:
-        return None
+        return None, "tokenizer_encode_failed"
 
     message_ids = None
     if message:
@@ -186,13 +200,14 @@ def _attach_thinking_budget_processor(
 
     from .logits_processors import ThinkingTokenBudgetLogitsProcessor
 
-    return ThinkingTokenBudgetLogitsProcessor(
+    processor = ThinkingTokenBudgetLogitsProcessor(
         budget=budget,
         start_token_ids=start_ids,
         end_token_ids=end_ids,
         message_token_ids=message_ids,
         prompt_token_ids=prompt_token_ids,
     )
+    return processor, None
 
 
 # Error patterns that indicate cache corruption
@@ -1823,7 +1838,7 @@ class Scheduler:
           - None  when no budget was requested (default).
         """
         sp = request.sampling_params
-        tb_proc = _attach_thinking_budget_processor(
+        tb_proc, noop_reason = _attach_thinking_budget_processor(
             tokenizer=self.tokenizer,
             reasoning_parser=self._reasoning_parser,
             budget=sp.thinking_token_budget,
@@ -1833,6 +1848,7 @@ class Scheduler:
         if tb_proc is not None:
             request.logits_processors.append(tb_proc)
             request.thinking_budget_applied = True
+            request.thinking_budget_noop_reason = None
         elif sp.thinking_token_budget is not None:
             _parser_name = (
                 type(self._reasoning_parser).__name__
@@ -1876,8 +1892,10 @@ class Scheduler:
                 # Task 6 creates vllm_mlx.metrics; tolerate its absence.
                 pass
             request.thinking_budget_applied = False
+            request.thinking_budget_noop_reason = noop_reason
         else:
             request.thinking_budget_applied = None
+            request.thinking_budget_noop_reason = None
 
     def add_request(self, request: Request) -> None:
         """

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2273,6 +2273,7 @@ class Scheduler:
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
                 thinking_budget_applied=request.thinking_budget_applied,
+                thinking_budget_noop_reason=request.thinking_budget_noop_reason,
             )
 
             # Check if finished
@@ -2652,12 +2653,18 @@ class Scheduler:
                     _applied = (
                         _req.thinking_budget_applied if _req is not None else None
                     )
+                    _noop_reason = (
+                        _req.thinking_budget_noop_reason
+                        if _req is not None
+                        else None
+                    )
                     output.outputs.append(
                         RequestOutput(
                             request_id=rid,
                             finished=True,
                             finish_reason="error",
                             thinking_budget_applied=_applied,
+                            thinking_budget_noop_reason=_noop_reason,
                         )
                     )
                 output.finished_request_ids = aborted_ids

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -269,6 +269,37 @@ def _build_thinking_budget_headers(
     return headers
 
 
+def _warn_if_max_tokens_below_floor(
+    resolved: ResolvedBudget,
+    max_tokens: int | None,
+) -> None:
+    """Log a WARN when the client's max_tokens is below the resolver's
+    max_tokens_floor. Sibling to PR #12's sizing-guardrail WARN.
+
+    The floor is advisory — the resolver does not coerce max_tokens
+    server-side because some clients legitimately want minimal content
+    output. But the most common mistake is setting effort=high and leaving
+    max_tokens at the SDK default (~4096) — thinking truncates mid-stream
+    and the result looks worse than effort=off. This WARN surfaces the
+    mistake in server logs so operators can fix their clients.
+    """
+    if max_tokens is None or resolved.max_tokens_floor is None:
+        return
+    if max_tokens >= resolved.max_tokens_floor:
+        return
+    logger.warning(
+        "[thinking-budget-resolver] effort=%s resolved to budget=%s with "
+        "max_tokens_floor=%d, but client set max_tokens=%d. Thinking will "
+        "likely truncate mid-stream. Increase max_tokens to >= %d for "
+        "full effort, or lower the effort level.",
+        resolved.effort_label or resolved.source.value,
+        resolved.budget,
+        resolved.max_tokens_floor,
+        max_tokens,
+        resolved.max_tokens_floor,
+    )
+
+
 def _anthropic_budget_requested(anthropic_request) -> bool:
     """Return True iff the Anthropic request asked for a thinking budget
     via EITHER the vllm-mlx extension field `thinking_token_budget` OR
@@ -1745,6 +1776,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         # for header-emission purposes.
         budget_was_requested = True
 
+    # Also WARN if max_tokens is below the resolver's advisory floor.
+    # Sibling of PR #12's sizing guardrail — catches the common "effort=high
+    # with SDK-default max_tokens" truncation mistake.
+    _warn_if_max_tokens_below_floor(_resolved_budget, request.max_tokens)
+
     # Add tools if provided
     if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
@@ -1971,6 +2007,11 @@ async def create_anthropic_message(
     # TODO(context_window): plumb real context_window from the loaded model
     # config (the adapter defaults to 131072 today).
     openai_request, _resolved_budget = anthropic_to_openai(anthropic_request)
+
+    # Also WARN if max_tokens is below the resolver's advisory floor.
+    # Sibling of PR #12's sizing guardrail — catches the common "effort=high
+    # with SDK-default max_tokens" truncation mistake.
+    _warn_if_max_tokens_below_floor(_resolved_budget, anthropic_request.max_tokens)
 
     if anthropic_request.stream:
         headers = {"Cache-Control": "no-cache", "Connection": "keep-alive"}

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -199,16 +199,47 @@ def _streaming_header_value(
     return "true"
 
 
+def _streaming_noop_reason(
+    *, is_mllm: bool, reasoning_parser, engine_supports_budget: bool
+) -> str | None:
+    """Streaming pre-flight: map the same engine-state tuple used by
+    `_streaming_header_value` onto a ``noop_reason`` string when the
+    processor is known NOT to attach. Returns None when the processor
+    is likely to attach.
+
+    Reason strings match ``Request.thinking_budget_noop_reason`` so the
+    streaming pre-flight header agrees with the non-streaming path that
+    reads the value off ``RequestOutput``:
+      - ``"mllm_path"``             — MLLM engines skip logits_processors
+      - ``"simple_engine"``         — SimpleEngine path ignores budget
+      - ``"parser_not_configured"`` — no --reasoning-parser wired
+    """
+    if is_mllm:
+        return "mllm_path"
+    if not engine_supports_budget:
+        return "simple_engine"
+    if reasoning_parser is None:
+        return "parser_not_configured"
+    return None
+
+
 def _build_thinking_budget_headers(
     resolved: ResolvedBudget,
     applied: bool | None,
+    noop_reason: str | None = None,
 ) -> dict[str, str]:
-    """Build the four x-thinking-budget-* response headers from a ResolvedBudget.
+    """Build the x-thinking-budget-* response headers from a ResolvedBudget.
 
     `applied` is the pre-existing bool/None the emission sites were computing
     before this change (based on whether the logits processor attached and the
     family can enforce). It stays separate because applied = "did it actually
     work" != resolved = "what did we decide to try."
+
+    `noop_reason`, when present with applied=False, surfaces WHY the processor
+    didn't attach (e.g. ``"simple_engine"``, ``"mllm_path"``,
+    ``"parser_not_configured"``, ``"tokenizer_encode_failed"``). Operators
+    need this to diagnose silent no-ops — without it, the only signal is
+    `applied=false` with no root cause (the arena incident on 2026-04-18).
     """
     headers: dict[str, str] = {}
 
@@ -227,6 +258,13 @@ def _build_thinking_budget_headers(
     # 4. x-thinking-budget-max-tokens-floor — recommended min max_tokens.
     if resolved.max_tokens_floor is not None:
         headers["x-thinking-budget-max-tokens-floor"] = str(resolved.max_tokens_floor)
+
+    # 5. x-thinking-budget-noop-reason — emitted ONLY when applied is False.
+    # Tells operators WHY the processor didn't attach (simple_engine vs
+    # mllm_path vs parser_not_configured vs tokenizer_encode_failed). Absent
+    # when applied is True or no budget was requested.
+    if applied is False and noop_reason:
+        headers["x-thinking-budget-noop-reason"] = noop_reason
 
     return headers
 
@@ -1722,10 +1760,16 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 reasoning_parser=getattr(engine, "_reasoning_parser", None),
                 engine_supports_budget=isinstance(engine, BatchedEngine),
             )
+            _streaming_noop = _streaming_noop_reason(
+                is_mllm=getattr(engine, "_is_mllm", False),
+                reasoning_parser=getattr(engine, "_reasoning_parser", None),
+                engine_supports_budget=isinstance(engine, BatchedEngine),
+            )
             stream_headers.update(
                 _build_thinking_budget_headers(
                     _resolved_budget,
                     applied=(streaming_applied == "true"),
+                    noop_reason=_streaming_noop,
                 )
             )
         elif _resolved_budget.source != EffortSource.DEFAULT:
@@ -1821,11 +1865,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         from fastapi.responses import JSONResponse
 
         applied = getattr(output, "thinking_budget_applied", None)
+        noop_reason = getattr(output, "thinking_budget_noop_reason", None)
         return JSONResponse(
             content=chat_response.model_dump(mode="json", exclude_none=True),
             headers=_build_thinking_budget_headers(
                 _resolved_budget,
                 applied=(applied is True),
+                noop_reason=noop_reason,
             ),
         )
 
@@ -1934,10 +1980,16 @@ async def create_anthropic_message(
                 reasoning_parser=getattr(engine, "_reasoning_parser", None),
                 engine_supports_budget=isinstance(engine, BatchedEngine),
             )
+            _streaming_noop = _streaming_noop_reason(
+                is_mllm=getattr(engine, "_is_mllm", False),
+                reasoning_parser=getattr(engine, "_reasoning_parser", None),
+                engine_supports_budget=isinstance(engine, BatchedEngine),
+            )
             headers.update(
                 _build_thinking_budget_headers(
                     _resolved_budget,
                     applied=(streaming_applied == "true"),
+                    noop_reason=_streaming_noop,
                 )
             )
         elif _resolved_budget.source != EffortSource.DEFAULT:
@@ -2034,10 +2086,12 @@ async def create_anthropic_message(
     _resp_headers: dict[str, str] = {}
     if _anthropic_budget_requested(anthropic_request):
         applied = getattr(output, "thinking_budget_applied", None)
+        noop_reason = getattr(output, "thinking_budget_noop_reason", None)
         _resp_headers.update(
             _build_thinking_budget_headers(
                 _resolved_budget,
                 applied=(applied is True),
+                noop_reason=noop_reason,
             )
         )
     elif _resolved_budget.source != EffortSource.DEFAULT:


### PR DESCRIPTION
## Summary

Adds operator-visible diagnosis for thinking-budget no-op cases + advisory WARN for the `max_tokens < floor` mistake. Closes M2, M3, M5, M6, M7, M8 from the PR #13 post-impl /dc review.

**Concretely, this PR:**
- Adds `thinking_budget_noop_reason: str | None` to `Request`, `RequestOutput`, and `GenerationOutput`, with 5 enumerated values covering every no-op path
- Plumbs the reason through the scheduler, both engines (Simple + Batched), MLLM path, and output collector (including a prefer-non-None merge rule matching the existing `applied` rule)
- Emits `x-thinking-budget-noop-reason` header at all 8 call sites (non-streaming + streaming for both `/v1/chat/completions` and `/v1/messages`). Streaming pre-flight uses a sibling dispatch helper
- Adds a sibling WARN to PR #12's sizing guardrail: `[thinking-budget-resolver] effort=high resolved to budget=8192 with max_tokens_floor=16384, but client set max_tokens=4000. Thinking will likely truncate mid-stream.`
- Updates UPSTREAM_PIN invariant #12 to 5-header contract

## Why this matters

Yesterday an arena session misdiagnosed a `SimpleEngine` launch-config issue as a broken `thinking_budget.py` logits processor, costing two sessions of effort. The `applied: false` header was truthful but silent about WHY. With this PR, the same request now returns `x-thinking-budget-noop-reason: simple_engine` — one-shot diagnosis, no speculation.

Live verified against a SimpleEngine server:
\`\`\`
x-thinking-budget-applied: false
x-thinking-budget-resolved: 0
x-thinking-budget-source: top_level
x-thinking-budget-noop-reason: simple_engine
\`\`\`

## Reason values

| value | when |
|---|---|
| `parser_not_configured` | server started without `--reasoning-parser` |
| `tokenizer_encode_failed` | start/end delimiter encode raised or returned empty |
| `multi_token_delimiter` | reserved; current code doesn't length-check encodes (deferred) |
| `mllm_path` | MLLM engine ignores logits_processors |
| `simple_engine` | SimpleEngine path does not run logits_processors (fix: `--continuous-batching`) |

## Test plan
- [x] 90 unit tests pass locally across the touched modules
- [x] Live verification: spawned SimpleEngine server and confirmed header emission
- [x] Full suite (minus pre-existing async-plugin failures): 1234 pass, 9 skipped, 12 failures unrelated to this change

## Commits
10 commits — see branch log. Task breakdown followed the v2 plan at `docs/superpowers/plans/2026-04-19-pr13-followup-fixes-v2.md` (PR-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)