### PR TITLE
fix(cache): DELETE /v1/cache refuses when blocks in use; 3-tier guard

### DIFF
--- a/tests/test_cache_endpoints.py
+++ b/tests/test_cache_endpoints.py
@@ -20,17 +20,46 @@ def _build_app_with_prefix_cache(prefix_cache):
 
 
 def test_clear_cache_calls_prefix_cache_clear_when_present():
-    prefix_cache = MagicMock()
-    prefix_cache.clear = MagicMock()
+    """Adapter now returns (all_cleared, refused_tiers). Handler surfaces
+    both to the response body."""
+    from vllm_mlx.server import app
 
-    app = _build_app_with_prefix_cache(prefix_cache)
+    adapter = MagicMock()
+    adapter.clear = MagicMock(return_value=(True, []))  # new contract
+    app.state.prefix_cache = adapter
+
     client = TestClient(app)
 
     resp = client.delete("/v1/cache")
     assert resp.status_code == 200
     body = resp.json()
-    assert "llm_prefix" in body["caches"]
-    prefix_cache.clear.assert_called_once()
+    caches = {c["name"]: c for c in body["caches"]}
+    assert "llm_prefix" in caches
+    assert caches["llm_prefix"]["cleared"] is True
+    assert caches["llm_prefix"]["refused_tiers"] == []
+    adapter.clear.assert_called_once()
+
+
+def test_clear_cache_returns_409_when_any_tier_refuses():
+    """Returns HTTP 409 when at least one LLM prefix tier refuses."""
+    from vllm_mlx.server import app
+
+    adapter = MagicMock()
+    adapter.clear = MagicMock(return_value=(False, ["memory_aware_cache"]))
+    app.state.prefix_cache = adapter
+
+    client = TestClient(app)
+
+    resp = client.delete("/v1/cache")
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["status"] == "refused"
+    assert detail["refused_tiers"] == ["memory_aware_cache"]
+    assert (
+        "in-flight" in detail["message"].lower()
+        or "blocks" in detail["message"].lower()
+        or "traffic" in detail["message"].lower()
+    )
 
 
 def test_clear_cache_skips_prefix_cache_when_absent():
@@ -43,7 +72,8 @@ def test_clear_cache_skips_prefix_cache_when_absent():
     resp = client.delete("/v1/cache")
     assert resp.status_code == 200
     body = resp.json()
-    assert "llm_prefix" not in body["caches"]
+    names = {c["name"] for c in body["caches"]} if body["caches"] else set()
+    assert "llm_prefix" not in names
 
 
 def test_cache_stats_includes_prefix_cache_when_present():
@@ -75,3 +105,63 @@ def test_cache_stats_omits_prefix_cache_when_absent():
     assert resp.status_code == 200
     body = resp.json()
     assert "llm_prefix_cache" not in body
+
+
+def test_adapter_clear_returns_empty_refused_when_no_scheduler():
+    """No scheduler wired -> clear returns (True, []) — nothing to refuse."""
+    from vllm_mlx.server import _PrefixCacheEndpointAdapter
+
+    class _NoSchedEngine:
+        _engine = None
+
+    adapter = _PrefixCacheEndpointAdapter(_NoSchedEngine())
+    assert adapter.clear() == (True, [])
+
+
+def test_adapter_clear_aggregates_refusals_from_three_tiers():
+    """Adapter walks memory_aware_cache, block_aware_cache, prefix_cache and
+    collects tier names whose clear() returned False."""
+    from vllm_mlx.server import _PrefixCacheEndpointAdapter
+
+    scheduler = MagicMock()
+    scheduler.memory_aware_cache.clear = MagicMock(return_value=False)
+    scheduler.block_aware_cache.clear = MagicMock(return_value=True)
+    scheduler.prefix_cache.clear = MagicMock(return_value=False)
+
+    class _Engine:
+        pass
+
+    engine = _Engine()
+    # Compose the nesting the adapter walks: engine._engine.engine.scheduler
+    core = MagicMock()
+    core.engine.scheduler = scheduler
+    engine._engine = core
+
+    adapter = _PrefixCacheEndpointAdapter(engine)
+    all_cleared, refused = adapter.clear()
+    assert all_cleared is False
+    assert set(refused) == {"memory_aware_cache", "prefix_cache"}
+
+
+def test_adapter_clear_treats_none_return_as_success():
+    """Legacy tiers predating the bool contract return None; treat as success."""
+    from vllm_mlx.server import _PrefixCacheEndpointAdapter
+
+    scheduler = MagicMock()
+    scheduler.memory_aware_cache.clear = MagicMock(return_value=None)
+    scheduler.block_aware_cache.clear = MagicMock(return_value=True)
+    # No prefix_cache attribute.
+    del scheduler.prefix_cache
+
+    class _Engine:
+        pass
+
+    engine = _Engine()
+    core = MagicMock()
+    core.engine.scheduler = scheduler
+    engine._engine = core
+
+    adapter = _PrefixCacheEndpointAdapter(engine)
+    all_cleared, refused = adapter.clear()
+    assert all_cleared is True
+    assert refused == []

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -442,3 +442,58 @@ class TestGetAvailableMemory:
             # Should return 0 when psutil not available
             # Note: This test may not work as expected due to import caching
             pass
+
+
+class TestClearInFlightGuard:
+    """PR-A Task A.1 — in-flight guard for DELETE /v1/cache.
+
+    Mirrors the PagedCacheManager.reset_prefix_cache() pattern in
+    paged_cache.py:1149-1156 ("refuse when entries are in use"). The
+    adapter caller aggregates refusals so DELETE /v1/cache returns HTTP
+    409 Conflict instead of proceeding and crashing mid-decode.
+    """
+
+    @pytest.fixture
+    def model(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def cache(self, model):
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=10)
+        return MemoryAwarePrefixCache(model, config)
+
+    def test_clear_refuses_when_entries_in_use(self, cache):
+        """clear() must return False when entries are held by in-flight
+        requests, so the endpoint can return 409 instead of wiping state
+        that live decode still reads."""
+        cache._mark_in_use_for_test()
+        result = cache.clear()
+        assert result is False, "clear() must refuse when entries are in use"
+
+    def test_clear_returns_true_when_idle(self, cache):
+        """Idle cache clears normally and reports success."""
+        assert cache.clear() is True
+
+    def test_clear_wipes_entries_when_idle(self, cache):
+        """Idle clear still performs the full wipe (no regression)."""
+
+        def _mock_kv(size_bytes: int):
+            return [MockKVCache(size_bytes // 2, size_bytes // 2)]
+
+        cache.store([1, 2, 3], _mock_kv(1000))
+        assert len(cache) == 1
+        assert cache.clear() is True
+        assert len(cache) == 0
+
+    def test_clear_preserves_entries_when_refused(self, cache):
+        """A refused clear must NOT wipe state — that's the whole point."""
+
+        def _mock_kv(size_bytes: int):
+            return [MockKVCache(size_bytes // 2, size_bytes // 2)]
+
+        cache.store([1, 2, 3], _mock_kv(1000))
+        cache._mark_in_use_for_test()
+        assert cache.clear() is False
+        assert len(cache) == 1, (
+            "refused clear must leave entries intact for live decoders"
+        )

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -522,7 +522,7 @@ class TestStatistics:
         assert manager.stats.cache_misses == 0
         assert manager.stats.cow_copies == 0
 
-    def test_clear(self):
+    def test_clear_when_idle(self):
         """Test clearing all cache."""
         from vllm_mlx.paged_cache import PagedCacheManager
 
@@ -533,6 +533,13 @@ class TestStatistics:
         block = manager.allocate_block()
         manager.add_block_to_table(table, block, 64)
 
+        # Drain any allocations so clear() is allowed by the new in-flight guard.
+        # After Task A.4, PagedCacheManager.clear() refuses when num_used > 1.
+        for block_id in list(manager.allocated_blocks.keys()):
+            b = manager.allocated_blocks[block_id]
+            if not getattr(b, "is_null", False):
+                manager.free_block(block_id)
+
         manager.clear()
 
         # After clear, null block is re-reserved
@@ -540,6 +547,21 @@ class TestStatistics:
         assert len(manager.allocated_blocks) == 1  # only null block
         assert len(manager.request_tables) == 0
         assert len(manager.hash_to_block) == 0
+
+    def test_clear_refuses_when_blocks_in_use(self):
+        """PagedCacheManager.clear() refuses (returns False) when blocks are
+        allocated to in-flight requests. Matches the reset_prefix_cache guard
+        at paged_cache.py:1149-1156."""
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=64, max_blocks=16)
+        block = manager.allocate_block()
+        assert block is not None
+
+        result = manager.clear()
+        assert result is False
+        # State preserved.
+        assert block.block_id in manager.allocated_blocks
 
 
 class TestThreadSafety:
@@ -705,7 +727,7 @@ class TestBlockAwarePrefixCache:
         assert stats["misses"] == 1
         assert stats["hits"] == 0
 
-    def test_clear(self):
+    def test_clear_when_idle(self):
         """Test clearing cache."""
         from vllm_mlx.paged_cache import PagedCacheManager
         from vllm_mlx.prefix_cache import BlockAwarePrefixCache
@@ -718,6 +740,12 @@ class TestBlockAwarePrefixCache:
         cache.store_cache("req-2", tokens, ["data2"])
 
         assert len(cache) == 2
+
+        # Drain any allocations so clear() is allowed by the new in-flight guard.
+        # After Task A.4, PagedCacheManager.clear() refuses when num_used > 1.
+        # release_cache decrements ref counts via delete_block_table.
+        cache.release_cache("req-1")
+        cache.release_cache("req-2")
 
         cache.clear()
 

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -297,6 +297,74 @@ class TestSchedulerIntegration:
         assert default_config.prefix_cache_size == 100
 
 
+class TestBlockAwarePrefixCacheClear:
+    """Tests for BlockAwarePrefixCache.clear() delegate-first ordering.
+
+    PR-A Task A.2: clear() must delegate to paged_cache.clear() FIRST and
+    only wipe _request_tables / _prefix_index if the delegate succeeded.
+    Pre-fix, outer state was wiped before delegating, so a refusal by the
+    downstream PagedCacheManager guard (A.4) would leave the cache in a
+    partially-cleared inconsistent state.
+    """
+
+    def _make_cache(self):
+        """Build a BlockAwarePrefixCache with a mocked paged_cache.
+
+        The real constructor signature is (model, paged_cache_manager).
+        We use MagicMock for both; paged_cache_manager.block_size must be
+        an attribute read during __init__, so MagicMock suffices.
+        """
+        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+        paged_cache = MagicMock()
+        paged_cache.block_size = 64  # reasonable default
+        cache = BlockAwarePrefixCache(
+            model=MagicMock(), paged_cache_manager=paged_cache
+        )
+        return cache
+
+    def test_clear_refuses_when_paged_cache_refuses(self):
+        """clear() must check delegated PagedCacheManager result BEFORE
+        wiping _request_tables and _prefix_index. If delegate refuses,
+        outer state must remain intact."""
+        cache = self._make_cache()
+        cache.paged_cache.clear = MagicMock(return_value=False)  # refusal
+        cache._request_tables["req-1"] = MagicMock()
+        cache._prefix_index["hash-abc"] = MagicMock()
+
+        result = cache.clear()
+        assert result is False
+        # Critical: inner state NOT wiped.
+        assert "req-1" in cache._request_tables
+        assert "hash-abc" in cache._prefix_index
+
+    def test_clear_wipes_outer_state_when_paged_cache_succeeds(self):
+        """When delegate returns True, outer state is wiped and clear
+        returns True."""
+        cache = self._make_cache()
+        cache.paged_cache.clear = MagicMock(return_value=True)
+        cache._request_tables["req-1"] = MagicMock()
+        cache._prefix_index["hash-abc"] = MagicMock()
+
+        result = cache.clear()
+        assert result is True
+        assert len(cache._request_tables) == 0
+        assert len(cache._prefix_index) == 0
+
+    def test_clear_treats_none_delegate_return_as_success(self):
+        """Legacy tiers predating the bool contract return None; treat
+        as success so we don't break backwards compatibility."""
+        cache = self._make_cache()
+        cache.paged_cache.clear = MagicMock(return_value=None)  # legacy
+        cache._request_tables["req-1"] = MagicMock()
+        cache._prefix_index["hash-abc"] = MagicMock()
+
+        result = cache.clear()
+        assert result is True  # None treated as success
+        assert len(cache._request_tables) == 0
+        assert len(cache._prefix_index) == 0
+
+
 if __name__ == "__main__":
     # Verbose standalone test with real model
     import argparse

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -206,7 +206,9 @@ class TestPrefixCacheManager:
         cache_manager.store_cache([3, 4], ["cache2"])
         assert len(cache_manager) == 2
 
-        cache_manager.clear()
+        # PR-A A.3: clear() now returns bool (True on wipe, False on refusal).
+        result = cache_manager.clear()
+        assert result is True
         assert len(cache_manager) == 0
 
         # Stats should also be reset
@@ -363,6 +365,35 @@ class TestBlockAwarePrefixCacheClear:
         assert result is True  # None treated as success
         assert len(cache._request_tables) == 0
         assert len(cache._prefix_index) == 0
+
+
+class TestPrefixCacheManagerClearGuard:
+    """Tests for PrefixCacheManager.clear() in-flight guard.
+
+    PR-A Task A.3: clear() must refuse (return False) when requests are
+    actively using cached prefixes. Mirrors the guard in
+    PagedCacheManager.reset_prefix_cache (paged_cache.py:1149-1156) and
+    the A.1 guard on MemoryAwarePrefixCache.
+    """
+
+    def test_prefix_cache_manager_clear_refuses_when_active_requests(self):
+        """PrefixCacheManager.clear() must refuse when requests are actively
+        using cached prefixes. Mirrors the guard in PagedCacheManager
+        reset_prefix_cache (paged_cache.py:1149-1156)."""
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        mgr = PrefixCacheManager(MagicMock(), max_entries=10)
+        mgr._mark_in_use_for_test()
+
+        result = mgr.clear()
+        assert result is False
+
+    def test_prefix_cache_manager_clear_returns_true_when_idle(self):
+        """Idle manager clears normally and returns True."""
+        from vllm_mlx.prefix_cache import PrefixCacheManager
+
+        mgr = PrefixCacheManager(MagicMock(), max_entries=10)
+        assert mgr.clear() is True
 
 
 if __name__ == "__main__":

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -440,6 +440,18 @@ class MemoryAwarePrefixCache:
         # Track the match type from the last fetch() call
         self._last_match_type: str | None = None
 
+        # In-flight guard for clear() — PR-A Task A.1.
+        # Non-zero when entries are held by live requests; clear() refuses
+        # in that case so DELETE /v1/cache can return HTTP 409 instead of
+        # wiping state mid-decode and crashing the generation loop.
+        #
+        # NOTE: this is defense-in-depth only today. Concrete wiring from
+        # the scheduler (acquire on request enter, release on exit) is a
+        # follow-up — PagedCacheManager.reset_prefix_cache() is what
+        # actually protects the live system right now. See paged_cache.py
+        # lines ~1149-1156 for the reference guard pattern.
+        self._in_flight_count: int = 0
+
         logger.info(
             f"MemoryAwarePrefixCache initialized: "
             f"max_memory={self._max_memory / _BYTES_PER_MB:.1f}MB, "
@@ -809,13 +821,49 @@ class MemoryAwarePrefixCache:
             return True
         return False
 
-    def clear(self) -> None:
-        """Clear all cached entries."""
+    def clear(self) -> bool:
+        """Clear all cached entries.
+
+        Refuses (returns False) when any entry is held by an in-flight
+        request. The adapter caller aggregates refusals so DELETE
+        /v1/cache returns HTTP 409 when concurrent load prevents a safe
+        clear. Mirrors PagedCacheManager.reset_prefix_cache() in
+        paged_cache.py:1149-1156 (UPSTREAM_PIN cache-clear invariant —
+        see PR-A post-impl /dc).
+
+        Returns
+        -------
+        bool
+            True if the cache was wiped; False if the clear was refused
+            because entries are in use.
+        """
+        num_in_use = self._in_flight_count
+        if num_in_use > 0:
+            logger.warning(
+                "[prefix-cache-admin] MemoryAwarePrefixCache.clear refused: "
+                "%d entries in use. Drain traffic or wait for idle.",
+                num_in_use,
+            )
+            return False
+
         self._entries.clear()
         self._sorted_keys.clear()
         self._current_memory = 0
         self._stats = CacheStats(max_memory_bytes=self._max_memory)
         logger.debug("Cache cleared")
+        return True
+
+    # -----------------------------------------------------------------
+    # In-flight guard test helper — PR-A Task A.1
+    # -----------------------------------------------------------------
+    def _mark_in_use_for_test(self) -> None:
+        """Bump the in-flight counter so `clear()` refuses.
+
+        Test-only affordance. Production wiring (scheduler-side acquire
+        on request enter / release on exit) is a follow-up; today this
+        guard is defense-in-depth behind PagedCacheManager's guard.
+        """
+        self._in_flight_count += 1
 
     def get_stats(self) -> dict[str, Any]:
         """Get cache statistics."""

--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -1168,9 +1168,28 @@ class PagedCacheManager:
             logger.info("Prefix cache reset successfully")
             return True
 
-    def clear(self) -> None:
-        """Clear all cached data."""
+    def clear(self) -> bool:
+        """Clear all cached data.
+
+        Refuses (returns False) when any blocks are allocated to in-flight
+        requests. Mirrors the guard in ``reset_prefix_cache()`` at
+        paged_cache.py:1149-1156 so both admin paths fail safely under load.
+
+        Returns
+        -------
+        bool
+            True if wiped; False if refused because blocks are in use.
+        """
         with self._lock:
+            num_used = self.max_blocks - self.free_block_queue.num_free_blocks
+            if num_used > 1:  # null_block always counts as used
+                logger.warning(
+                    "[prefix-cache-admin] PagedCacheManager.clear refused: "
+                    "%d blocks in use.",
+                    num_used - 1,
+                )
+                return False
+
             # Recreate blocks and queue
             self.blocks = [CacheBlock(block_id=i) for i in range(self.max_blocks)]
             self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
@@ -1193,3 +1212,4 @@ class PagedCacheManager:
             )
 
             logger.info("PagedCacheManager cleared")
+            return True

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -113,6 +113,13 @@ class PrefixCacheManager:
         # Statistics
         self.stats = PrefixCacheStats()
 
+        # PR-A Task A.3: in-flight guard counter for clear() refusal.
+        # Defense-in-depth — PrefixCacheManager itself has no liveness
+        # tracking; production-side acquire/release wiring is a follow-up.
+        # Today the downstream PagedCacheManager guard is the authoritative
+        # one; this mirror keeps the contract uniform across cache tiers.
+        self._in_flight_count: int = 0
+
     def _search(
         self, tokens: List[int]
     ) -> Tuple[Optional[List[int]], Optional[List[int]], Optional[List[int]], int]:
@@ -341,11 +348,51 @@ class PrefixCacheManager:
         """Reset statistics."""
         self.stats = PrefixCacheStats()
 
-    def clear(self) -> None:
-        """Clear all cached entries."""
+    def clear(self) -> bool:
+        """Clear all cached prefix data.
+
+        Refuses (returns False) when any requests are actively holding
+        cached prefixes. The adapter caller
+        (``_PrefixCacheEndpointAdapter.clear``) aggregates refusals so
+        ``DELETE /v1/cache`` can return HTTP 409 when traffic is live.
+        Mirrors the PagedCacheManager ``reset_prefix_cache`` guard at
+        paged_cache.py:1149-1156 and the A.1 guard on
+        MemoryAwarePrefixCache.clear (PR-A cache-clear invariant — see
+        UPSTREAM_PIN in CLAUDE.md).
+
+        Returns
+        -------
+        bool
+            True if cache was wiped; False if refused because requests
+            are in flight.
+        """
+        num_in_use = self._in_flight_count
+        if num_in_use > 0:
+            logger.warning(
+                "[prefix-cache-admin] PrefixCacheManager.clear refused: "
+                "%d active requests. Drain traffic or wait for idle.",
+                num_in_use,
+            )
+            return False
+
         self._cache.clear()
         self._lru.clear()
         self.reset_stats()
+        logger.info("PrefixCacheManager cleared")
+        return True
+
+    # -----------------------------------------------------------------
+    # In-flight guard test helper — PR-A Task A.3
+    # -----------------------------------------------------------------
+    def _mark_in_use_for_test(self) -> None:
+        """Bump the in-flight counter so ``clear()`` refuses.
+
+        Test-only affordance. Production wiring (scheduler-side acquire
+        on request enter / release on exit) is a follow-up; today this
+        guard is defense-in-depth behind PagedCacheManager's guard.
+        Mirrors the A.1 helper on MemoryAwarePrefixCache.
+        """
+        self._in_flight_count += 1
 
     def __len__(self) -> int:
         """Return number of cached entries."""

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -940,12 +940,38 @@ class BlockAwarePrefixCache:
         self._tokens_saved = 0
         self.paged_cache.reset_stats()
 
-    def clear(self) -> None:
-        """Clear all cached data."""
+    def clear(self) -> bool:
+        """Clear all cached data.
+
+        Delegates to ``paged_cache.clear()`` FIRST. Only wipes our own
+        ``_request_tables`` / ``_prefix_index`` if the delegate succeeded.
+        This ordering is critical: pre-fix, we wiped outer state first,
+        so a delegate refusal (e.g. from the in-flight guard landing in
+        ``PagedCacheManager.clear()``) left the cache in a partially-
+        cleared inconsistent state worse than not clearing at all.
+
+        Returns
+        -------
+        bool
+            True if wiped (or delegate returned None for legacy contract);
+            False if delegate refused.
+        """
+        delegate_result = self.paged_cache.clear()
+        # None = legacy tier predating the bool contract = treat as success.
+        # False = explicit refusal — abort without touching outer state.
+        if delegate_result is False:
+            logger.warning(
+                "[prefix-cache-admin] BlockAwarePrefixCache.clear refused: "
+                "delegated paged_cache.clear returned False. Outer state "
+                "preserved."
+            )
+            return False
+
         self._request_tables.clear()
         self._prefix_index.clear()
-        self.paged_cache.clear()
         self.reset_stats()
+        logger.info("BlockAwarePrefixCache cleared")
+        return True
 
     def __len__(self) -> int:
         """Return number of active request entries."""

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -404,15 +404,32 @@ class _PrefixCacheEndpointAdapter:
                 return cache.get_stats()
         return None
 
-    def clear(self):
-        """Clear every prefix cache tier the scheduler holds."""
+    def clear(self) -> tuple[bool, list[str]]:
+        """Clear every prefix cache tier the scheduler holds.
+
+        Returns
+        -------
+        tuple[bool, list[str]]
+            ``(all_cleared, refused_tiers)``. ``all_cleared`` is True when
+            every tier that was touched succeeded (True) OR no tiers exist
+            OR every tier returned None (legacy pre-bool contract = success).
+            ``refused_tiers`` names tiers whose ``clear()`` explicitly
+            returned False (in-flight guard fired). When non-empty, the HTTP
+            handler returns 409.
+        """
         scheduler = self._scheduler()
         if scheduler is None:
-            return
+            return True, []
+        refused: list[str] = []
         for attr in ("memory_aware_cache", "block_aware_cache", "prefix_cache"):
             cache = getattr(scheduler, attr, None)
-            if cache is not None and hasattr(cache, "clear"):
-                cache.clear()
+            if cache is None or not hasattr(cache, "clear"):
+                continue
+            result = cache.clear()
+            # None = legacy success; False = explicit refusal.
+            if result is False:
+                refused.append(attr)
+        return (not refused, refused)
 
 
 def _get_cache_dir() -> str:
@@ -916,16 +933,36 @@ async def cache_stats():
 
 @app.delete("/v1/cache")
 async def clear_cache():
-    """Clear all caches held by this server (LLM prefix + mlx_vlm tiers)."""
-    cleared: list[str] = []
+    """Clear all caches held by this server (LLM prefix + mlx_vlm tiers).
+
+    The LLM prefix cache tiers (MemoryAwarePrefixCache / BlockAwarePrefixCache /
+    PrefixCacheManager) now refuse (return False from ``clear()``) when any
+    in-flight request is holding cached state. When any tier refuses, this
+    handler returns HTTP 409 with the full response shape plus a
+    ``refused_tiers`` list naming which tiers refused. Retry once traffic
+    drains.
+    """
+    caches: list[dict] = []
     errors: list[str] = []
+    refused_tiers: list[str] = []
 
     # LLM prefix cache (MemoryAwarePrefixCache) — only present when configured.
     prefix_cache = getattr(app.state, "prefix_cache", None)
     if prefix_cache is not None:
         try:
-            prefix_cache.clear()
-            cleared.append("llm_prefix")
+            result = prefix_cache.clear()
+            # Legacy adapters may return None; treat as success.
+            if isinstance(result, tuple):
+                all_cleared, tier_refused = result
+            else:
+                all_cleared, tier_refused = True, []
+            entry = {
+                "name": "llm_prefix",
+                "cleared": bool(all_cleared),
+                "refused_tiers": list(tier_refused),
+            }
+            caches.append(entry)
+            refused_tiers.extend(tier_refused)
         except Exception as e:
             errors.append(f"llm_prefix: {e}")
 
@@ -938,14 +975,35 @@ async def clear_cache():
 
         clear_multimodal_kv_cache()
         clear_pixel_values_cache()
-        cleared.extend(["multimodal_kv", "pixel_values", "pil_image"])
+        for name in ("multimodal_kv", "pixel_values", "pil_image"):
+            caches.append(
+                {"name": name, "cleared": True, "refused_tiers": []}
+            )
     except ImportError:
         pass  # not a VLM server; not an error
 
+    if refused_tiers:
+        # Any tier refused — surface 409 so operators can retry once traffic
+        # drains. Include the full response shape in `detail` so clients can
+        # still inspect per-cache state.
+        detail = {
+            "status": "refused",
+            "caches": caches,
+            "errors": errors or None,
+            "refused_tiers": refused_tiers,
+            "message": (
+                "One or more prefix cache tiers refused to clear because "
+                "in-flight requests are still holding cached blocks. Wait "
+                "for current traffic to drain, then retry DELETE /v1/cache."
+            ),
+        }
+        raise HTTPException(status_code=409, detail=detail)
+
     return {
-        "status": "cleared" if cleared else "noop",
-        "caches": cleared,
+        "status": "cleared" if caches else "noop",
+        "caches": caches,
         "errors": errors or None,
+        "refused_tiers": refused_tiers,
     }
 
 


### PR DESCRIPTION
## Summary

Closes pre-mortem Scenario 1 from the PR #13 post-impl /dc review: an operator hitting \`DELETE /v1/cache\` during live traffic could crash the generation loop with \`AttributeError: 'NoneType' object\` because the cache state was wiped mid-decode. Only \`PagedCacheManager.reset_prefix_cache()\` had an in-flight guard; the three caches that \`DELETE /v1/cache\` actually walks did not.

**This PR:**
- Adds in-flight guards to all three tiers the adapter touches:
  - \`MemoryAwarePrefixCache.clear()\` → \`bool\` + guard
  - \`BlockAwarePrefixCache.clear()\` → \`bool\` + **delegate-first ordering fix** (pre-fix, outer state wiped BEFORE the delegated call — so a refusal left partial corruption)
  - \`PrefixCacheManager.clear()\` → \`bool\` + guard
- Defense-in-depth on \`PagedCacheManager.clear()\` itself: returns \`bool\`, mirrors the \`reset_prefix_cache\` guard pattern (\`num_used > 1\`, accounting for null_block)
- \`_PrefixCacheEndpointAdapter.clear()\` now returns \`tuple[bool, list[str]]\` — \`(all_cleared, refused_tiers)\` — aggregating explicit False returns
- \`DELETE /v1/cache\` handler: HTTP 409 when any tier refuses, with \`refused_tiers\` and an operator-facing \`message\`. Success path still 200
- Renamed 2 existing tests (\`test_clear → test_clear_when_idle\`) with a drain-first pattern so they exercise the allowed-idle path
- Tests: 118 pass across memory_cache + prefix_cache + paged_cache + cache_endpoints test files

## API shape change (heads up for arena)

The \`caches\` field in the \`DELETE /v1/cache\` response changed from \`list[str]\` to \`list[dict]\` (each dict has \`name\`, \`cleared\`, \`refused_tiers\`). This was required to surface per-tier refusal info. Any client parsing the old \`list[str]\` shape needs updating. Grepped in-repo — no consumers found. External consumers (arena proxy) should treat this as a breaking response-shape change.

## Why these guards matter (not all "fire today")

- \`PagedCacheManager\` is the **authoritative** guard — it fires whenever real blocks are allocated to in-flight requests. This is the one that actually protects live traffic.
- \`MemoryAwarePrefixCache\` / \`PrefixCacheManager\` guards are **defense-in-depth**: those classes had no pre-existing liveness tracking, so their guards never fire in production today. But they harden the contract so a future scheduler-side acquire/release wiring can activate them without another schema change. The path from "defensive" to "active" is adding \`_in_flight_count\` bump/decrement at request enter/exit in the scheduler — a follow-up task, not blocking this PR
- \`BlockAwarePrefixCache\` ordering fix is a **real bug fix** — it doesn't have its own guard but its delegate (\`PagedCacheManager\`) does, and the pre-fix ordering meant a delegate refusal would leave \`BlockAware\`'s outer state partially wiped

## WARN prefix

All refusals log with \`[prefix-cache-admin]\` prefix for grep-uniqueness. Example:

\`\`\`
[prefix-cache-admin] PagedCacheManager.clear refused: 47 blocks in use.
\`\`\`

## Test plan
- [x] 118 unit tests pass across 4 cache-level test files
- [x] Full suite: 1255 pass, 12 pre-existing async-plugin failures unrelated to this change
- [ ] Manual: start a server, allocate via an in-flight streaming request, hit \`DELETE /v1/cache\`, expect 409 with \`refused_tiers\`

## Commits
5 commits — one per layer of the fix, bottom-up from the lowest tier to the HTTP handler:
\`\`\`
648d86b fix(server): DELETE /v1/cache returns 409 when tiers refuse; preserve shape
9ce95c8 fix(paged-cache): refuse clear() when blocks in use; update idle tests
3b6fd0f fix(prefix-cache-manager): refuse clear() when active requests
2a66db3 fix(block-aware-cache): delegate-first ordering + refuse propagation
6dd827b fix(memory-cache): refuse clear() when entries in use
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)