### PR TITLE
test: PR #13 coverage gaps — adapter chain + cross-dialect parity

### DIFF
--- a/tests/test_cache_endpoints.py
+++ b/tests/test_cache_endpoints.py
@@ -165,3 +165,68 @@ def test_adapter_clear_treats_none_return_as_success():
     all_cleared, refused = adapter.clear()
     assert all_cleared is True
     assert refused == []
+
+
+# ---- PR-E Task E.1: full adapter chain exercise ----
+
+
+def test_clear_walks_scheduler_attribute_chain():
+    """_PrefixCacheEndpointAdapter.clear() must walk the real
+    BatchedEngine._engine.engine.scheduler chain, not be mocked at
+    app.state. Regression guard: pre-fix, tests mocked at adapter level
+    and masked the scheduler-walking logic (PR #13 known follow-up #2)."""
+    from vllm_mlx.server import _PrefixCacheEndpointAdapter
+
+    scheduler = MagicMock()
+    cache_tier = MagicMock()
+    cache_tier.clear = MagicMock(return_value=True)
+    scheduler.memory_aware_cache = cache_tier
+    scheduler.block_aware_cache = None
+    scheduler.prefix_cache = None
+
+    core_engine = MagicMock()
+    core_engine.engine = MagicMock()
+    core_engine.engine.scheduler = scheduler
+
+    outer = MagicMock()
+    outer._engine = core_engine
+
+    adapter = _PrefixCacheEndpointAdapter(outer)
+    all_cleared, refused = adapter.clear()
+    assert all_cleared is True
+    assert refused == []
+    cache_tier.clear.assert_called_once()
+
+
+def test_stats_walks_scheduler_attribute_chain():
+    """GET /v1/cache/stats must similarly walk the real chain."""
+    from vllm_mlx.server import _PrefixCacheEndpointAdapter
+
+    scheduler = MagicMock()
+    scheduler.get_cache_stats = MagicMock(return_value={
+        "cache_hits": 100, "cache_misses": 5,
+    })
+    core_engine = MagicMock()
+    core_engine.engine = MagicMock()
+    core_engine.engine.scheduler = scheduler
+    outer = MagicMock()
+    outer._engine = core_engine
+
+    adapter = _PrefixCacheEndpointAdapter(outer)
+    stats = adapter.get_stats()
+    assert stats == {"cache_hits": 100, "cache_misses": 5}
+    scheduler.get_cache_stats.assert_called_once()
+
+
+def test_clear_handles_missing_scheduler_gracefully():
+    """When engine doesn't expose the expected chain (e.g., SimpleEngine
+    paths, test stubs), clear() must no-op rather than raise AttributeError."""
+    from vllm_mlx.server import _PrefixCacheEndpointAdapter
+
+    class _BrokenEngine:
+        _engine = None
+
+    adapter = _PrefixCacheEndpointAdapter(_BrokenEngine())
+    all_cleared, refused = adapter.clear()
+    assert all_cleared is True
+    assert refused == []

--- a/tests/test_thinking_budget_matrix.py
+++ b/tests/test_thinking_budget_matrix.py
@@ -561,3 +561,78 @@ def test_chat_completions_reasoning_effort(
         f"resolved={expected_budget_str!r}, got "
         f"{resp.headers.get('x-thinking-budget-resolved')!r}"
     )
+
+
+# ----- Cross-dialect parity (PR-E Task E.2) ---------------------------
+
+
+@pytest.mark.parametrize("spec", _MATRIX, ids=_matrix_ids)
+def test_dialect_parity_same_budget_same_output(spec: ModelSpec) -> None:
+    """Four dialects that all resolve to budget=8192 must produce comparable
+    reasoning_chars on the same prompt, at matched max_tokens.
+
+    Regression guard (pre-mortem S2 from PR #13 review): before v2 PR-C/D
+    fixes, output_config.effort=high could produce wildly different char
+    counts because max_tokens_floor wasn't enforced and SDK default
+    max_tokens varied.
+
+    Test logic (M-9 fix from v1 review): require every dialect to emit
+    SOME thinking (count > 0). If ALL four dialects emit zero, skip —
+    the model probably didn't use <think> tags on this prompt run.
+    """
+    _require_matrix()
+    if spec.family != "supported":
+        pytest.skip(f"{spec.name}: parity only meaningful for supported family")
+
+    PROMPT = "What is 2+2?"
+    MAX = 16384
+
+    bodies = [
+        {"max_tokens": MAX, "temperature": 0.3,
+         "thinking_token_budget": 8192},
+        {"max_tokens": MAX, "temperature": 0.3,
+         "chat_template_kwargs": {
+             "thinking": {"type": "enabled", "budget_tokens": 8192}
+         }},
+        {"max_tokens": MAX, "temperature": 0.3, "reasoning_effort": "high"},
+        {"max_tokens": MAX, "temperature": 0.3,
+         "chat_template_kwargs": {"output_config": {"effort": "high"}}},
+    ]
+    labels = ["top_level", "anthropic_thinking_enabled",
+              "openai_reasoning_effort", "output_config_effort"]
+    r_chars: list[int] = []
+
+    for body, _label in zip(bodies, labels):
+        body["model"] = spec.model
+        body["messages"] = [{"role": "user", "content": PROMPT}]
+        resp = requests.post(
+            f"{spec.url}/v1/chat/completions", json=body, timeout=_TIMEOUT_SEC,
+        )
+        resp.raise_for_status()
+        msg = (resp.json().get("choices") or [{}])[0].get("message") or {}
+        r_chars.append(len(msg.get("reasoning") or ""))
+
+    if all(c == 0 for c in r_chars):
+        pytest.skip(
+            f"{spec.name}: model emitted no <think> tags on any dialect "
+            f"run — likely a model/prompt property, not a regression."
+        )
+
+    # M-9 fix: require every dialect to emit SOME thinking.
+    # Pre-fix, `count == 0 or ratio_ok` masked real regressions where
+    # some dialects emitted zero while others emitted normally.
+    for count, label in zip(r_chars, labels):
+        assert count > 0, (
+            f"{spec.name}/{label}: reasoning_chars=0 while another dialect "
+            f"produced non-zero. Likely a resolver / sizing drift. "
+            f"All: {dict(zip(labels, r_chars))}"
+        )
+
+    # All non-zero. Ratio parity within 3x (tolerant for temp=0.3 noise).
+    median = sorted(r_chars)[len(r_chars) // 2]
+    for count, label in zip(r_chars, labels):
+        assert 0.33 * median <= count <= 3.0 * median, (
+            f"{spec.name}/{label}: r_chars={count} > 3x from median={median}. "
+            f"Dialect likely produces different effective budget. "
+            f"All: {dict(zip(labels, r_chars))}"
+        )


### PR DESCRIPTION
## Summary

Final PR of the PR #13 follow-up series. Addresses M-9 + C-4 test-gap findings from the post-impl /dc review with test-only additions. Zero production code changes.

**Two test additions:**

1. **Adapter scheduler-walking exercise** (3 tests in \`tests/test_cache_endpoints.py\`) — existing cache-endpoint tests mocked at \`app.state.prefix_cache\`, masking the attribute-walking logic that the adapter was written to exercise. These new tests construct the real \`engine._engine.engine.scheduler\` chain with MagicMocks so rebase-induced attribute drift is caught:
   - \`test_clear_walks_scheduler_attribute_chain\`
   - \`test_stats_walks_scheduler_attribute_chain\`
   - \`test_clear_handles_missing_scheduler_gracefully\`

2. **Cross-dialect parity matrix test** (1 parametrized test in \`tests/test_thinking_budget_matrix.py\`) — asserts that when four dialects (\`thinking_token_budget\`, \`thinking.type=enabled\`, \`reasoning_effort\`, \`output_config.effort\`) all resolve to budget=8192 at matched \`max_tokens=16384\`, they produce comparable \`reasoning_chars\` within 3x of the median. Pre-PR-C/D, \`output_config.effort=high\` silently differed from the other dialects because the floor wasn't enforced and SDK-default max_tokens varied. The M-9 logic fix: **every** dialect must emit thinking > 0, not "all or none" (which could mask 2/4 regressing to zero).

## Test plan
- [x] \`tests/test_cache_endpoints.py\`: 11/11 pass (8 pre-existing + 3 new)
- [x] \`tests/test_thinking_budget_matrix.py\`: new test collected; runs against live matrix servers when \`THINKING_BUDGET_MATRIX\` env var is populated, skips cleanly otherwise

## Commits
\`\`\`
378d758 test(matrix): cross-dialect parity — all four dialects must emit thinking
08d2284 test(cache): exercise full adapter scheduler-walking chain
\`\`\`

## Context

This completes the PR-A / PR-C / PR-D / PR-E sequence addressing the PR #13 post-impl /dc findings. See \`docs/superpowers/plans/2026-04-19-pr13-followup-fixes-v2.md\` for the full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)