### PR TITLE
feat(cache): wire production acquire/release on defensive cache tiers

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -497,3 +497,57 @@ class TestClearInFlightGuard:
         assert len(cache) == 1, (
             "refused clear must leave entries intact for live decoders"
         )
+
+
+# ---- acquire/release production API ----
+
+def test_acquire_blocks_clear_release_allows_it():
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache
+
+    cache = MemoryAwarePrefixCache(model=None)
+    cache.acquire("req-A")
+
+    assert cache.clear() is False  # refused while req-A holds
+
+    cache.release("req-A")
+    assert cache.clear() is True   # allowed after release
+
+
+def test_acquire_is_idempotent():
+    """Double-acquire of same request_id is a no-op (set semantics)."""
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache
+
+    cache = MemoryAwarePrefixCache(model=None)
+    cache.acquire("req-A")
+    cache.acquire("req-A")
+    cache.acquire("req-A")
+    assert cache._in_flight_count == 1
+
+    cache.release("req-A")
+    assert cache._in_flight_count == 0
+
+
+def test_release_unknown_id_is_silent_noop():
+    """Release of id never acquired doesn't error or underflow."""
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache
+
+    cache = MemoryAwarePrefixCache(model=None)
+    cache.release("never-acquired")
+    assert cache._in_flight_count == 0
+    assert cache.clear() is True
+
+
+def test_acquire_release_multiple_requests_independent():
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache
+
+    cache = MemoryAwarePrefixCache(model=None)
+    cache.acquire("req-A")
+    cache.acquire("req-B")
+    assert cache._in_flight_count == 2
+
+    cache.release("req-A")
+    assert cache._in_flight_count == 1
+    assert cache.clear() is False  # req-B still holds
+
+    cache.release("req-B")
+    assert cache.clear() is True

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -685,3 +685,36 @@ if __name__ == "__main__":
             print("=" * 70)
 
     asyncio.run(run_cache_test())
+
+
+# ---- acquire/release production API ----
+
+def test_prefix_cache_manager_acquire_blocks_clear():
+    from vllm_mlx.prefix_cache import PrefixCacheManager
+
+    mgr = PrefixCacheManager(model=None)
+    mgr.acquire("req-A")
+    assert mgr.clear() is False
+
+    mgr.release("req-A")
+    assert mgr.clear() is True
+
+
+def test_prefix_cache_manager_acquire_idempotent():
+    from vllm_mlx.prefix_cache import PrefixCacheManager
+
+    mgr = PrefixCacheManager(model=None)
+    mgr.acquire("req-A")
+    mgr.acquire("req-A")
+    assert mgr._in_flight_count == 1
+
+    mgr.release("req-A")
+    assert mgr._in_flight_count == 0
+
+
+def test_prefix_cache_manager_release_unknown_is_noop():
+    from vllm_mlx.prefix_cache import PrefixCacheManager
+
+    mgr = PrefixCacheManager(model=None)
+    mgr.release("never-acquired")
+    assert mgr._in_flight_count == 0

--- a/tests/test_scheduler_cache_hold.py
+++ b/tests/test_scheduler_cache_hold.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration test: Scheduler acquire/release wiring produces the right
+behavior on the active defensive cache tier.
+
+Pre-fix, MemoryAwarePrefixCache and PrefixCacheManager had a defensive
+guard but no production callers — the guard could only be exercised via
+the test-helper. Now add_request / remove_finished_request / abort
+drive acquire / release, so clear() reflects real scheduler state.
+
+These tests use mock model + tokenizer (no MLX/Metal). They exercise
+Scheduler.add_request → cache.clear() refuses → Scheduler.remove_finished_request
+→ cache.clear() allowed, through the same code paths used in production.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+@pytest.fixture
+def mock_tokenizer():
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda x: list(range(len(x.split())))
+    tokenizer.decode = lambda x: " ".join(str(t) for t in x)
+    tokenizer.eos_token_id = 0
+    tokenizer.eos_token_ids = {0}
+    return tokenizer
+
+
+@pytest.fixture
+def mock_model():
+    return MagicMock()
+
+
+def _make_scheduler(mock_model, mock_tokenizer, *, use_memory_aware: bool):
+    """Build a scheduler forced onto either the memory-aware or legacy
+    prefix-cache tier. Paged/block-aware tiers have their own guards and
+    are skipped for this test."""
+    config = SchedulerConfig(
+        enable_prefix_cache=True,
+        use_paged_cache=False,
+        use_memory_aware_cache=use_memory_aware,
+    )
+    return Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+
+
+def _submit(scheduler: Scheduler, request_id: str) -> Request:
+    req = Request(
+        request_id=request_id,
+        prompt="hello world test prompt",
+        sampling_params=SamplingParams(max_tokens=10),
+    )
+    scheduler.add_request(req)
+    return req
+
+
+def test_memory_aware_cache_clear_refused_while_request_in_flight(
+    mock_model, mock_tokenizer
+):
+    """Scheduler.add_request must acquire on memory_aware_cache so clear()
+    refuses, and remove_finished_request must release so clear() recovers."""
+    scheduler = _make_scheduler(mock_model, mock_tokenizer, use_memory_aware=True)
+    cache = scheduler.memory_aware_cache
+    assert cache is not None, "expected memory-aware tier to be active"
+
+    _submit(scheduler, "req-A")
+    assert cache.clear() is False  # refused — req-A is live
+
+    scheduler.remove_finished_request("req-A")
+    assert cache.clear() is True   # released — clear succeeds
+
+
+def test_prefix_cache_manager_clear_refused_while_request_in_flight(
+    mock_model, mock_tokenizer
+):
+    """Same contract on the legacy PrefixCacheManager tier."""
+    scheduler = _make_scheduler(mock_model, mock_tokenizer, use_memory_aware=False)
+    cache = scheduler.prefix_cache
+    assert cache is not None, "expected legacy prefix cache tier to be active"
+
+    _submit(scheduler, "req-B")
+    assert cache.clear() is False
+
+    scheduler.remove_finished_request("req-B")
+    assert cache.clear() is True
+
+
+def test_abort_path_releases_cache_hold(mock_model, mock_tokenizer):
+    """_do_abort_request must release so operators can clear after an
+    abort even if the engine loop hasn't popped the finished request yet."""
+    scheduler = _make_scheduler(mock_model, mock_tokenizer, use_memory_aware=True)
+    cache = scheduler.memory_aware_cache
+    assert cache is not None
+
+    _submit(scheduler, "req-C")
+    assert cache.clear() is False
+
+    # Defer path: abort_request enqueues, then executor drains via
+    # _process_pending_aborts. The public abort_request -> _process ->
+    # _do_abort_request pipeline is what fires in production.
+    scheduler.abort_request("req-C")
+    scheduler._process_pending_aborts()
+
+    assert cache.clear() is True
+
+
+def test_multiple_requests_released_independently(mock_model, mock_tokenizer):
+    scheduler = _make_scheduler(mock_model, mock_tokenizer, use_memory_aware=True)
+    cache = scheduler.memory_aware_cache
+    assert cache is not None
+
+    _submit(scheduler, "req-D")
+    _submit(scheduler, "req-E")
+    assert cache._in_flight_count == 2
+    assert cache.clear() is False
+
+    scheduler.remove_finished_request("req-D")
+    assert cache._in_flight_count == 1
+    assert cache.clear() is False  # req-E still holds
+
+    scheduler.remove_finished_request("req-E")
+    assert cache.clear() is True
+
+
+def test_paged_cache_path_does_not_require_acquire_release(
+    mock_model, mock_tokenizer
+):
+    """When paged cache is active, memory_aware_cache and prefix_cache are
+    both None, so the acquire/release helpers must no-op cleanly. The
+    paged tier's guard is authoritative via block refcounts."""
+    config = SchedulerConfig(
+        enable_prefix_cache=True,
+        use_paged_cache=True,
+    )
+    scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+    assert scheduler.memory_aware_cache is None
+    assert scheduler.prefix_cache is None
+    # Must not raise — helpers tolerate missing tiers.
+    scheduler._acquire_cache_hold("req-F")
+    scheduler._release_cache_hold("req-F")

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import bisect
 import logging
 import math
+import threading as _threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -440,17 +441,17 @@ class MemoryAwarePrefixCache:
         # Track the match type from the last fetch() call
         self._last_match_type: str | None = None
 
-        # In-flight guard for clear() — PR-A Task A.1.
-        # Non-zero when entries are held by live requests; clear() refuses
-        # in that case so DELETE /v1/cache can return HTTP 409 instead of
-        # wiping state mid-decode and crashing the generation loop.
+        # In-flight guard for clear() — PR-A Task A.1 + acquire/release
+        # wiring for production (follow-up). The set is the canonical
+        # representation; _in_flight_count is a derived view kept for
+        # backward compatibility with tests that read it directly.
         #
-        # NOTE: this is defense-in-depth only today. Concrete wiring from
-        # the scheduler (acquire on request enter, release on exit) is a
-        # follow-up — PagedCacheManager.reset_prefix_cache() is what
-        # actually protects the live system right now. See paged_cache.py
-        # lines ~1149-1156 for the reference guard pattern.
-        self._in_flight_count: int = 0
+        # acquire(req_id) and release(req_id) are called by the scheduler
+        # at request enter / exit. clear() refuses when the set is
+        # non-empty so DELETE /v1/cache returns HTTP 409 instead of
+        # wiping state mid-decode and crashing the generation loop.
+        self._in_flight_lock = _threading.Lock()
+        self._in_flight_ids: set[str] = set()
 
         logger.info(
             f"MemoryAwarePrefixCache initialized: "
@@ -837,33 +838,55 @@ class MemoryAwarePrefixCache:
             True if the cache was wiped; False if the clear was refused
             because entries are in use.
         """
-        num_in_use = self._in_flight_count
-        if num_in_use > 0:
-            logger.warning(
-                "[prefix-cache-admin] MemoryAwarePrefixCache.clear refused: "
-                "%d entries in use. Drain traffic or wait for idle.",
-                num_in_use,
-            )
-            return False
+        with self._in_flight_lock:
+            num_in_use = len(self._in_flight_ids)
+            if num_in_use > 0:
+                logger.warning(
+                    "[prefix-cache-admin] MemoryAwarePrefixCache.clear refused: "
+                    "%d entries in use. Drain traffic or wait for idle.",
+                    num_in_use,
+                )
+                return False
 
-        self._entries.clear()
-        self._sorted_keys.clear()
-        self._current_memory = 0
-        self._stats = CacheStats(max_memory_bytes=self._max_memory)
-        logger.debug("Cache cleared")
-        return True
+            self._entries.clear()
+            self._sorted_keys.clear()
+            self._current_memory = 0
+            self._stats = CacheStats(max_memory_bytes=self._max_memory)
+            logger.debug("Cache cleared")
+            return True
 
     # -----------------------------------------------------------------
-    # In-flight guard test helper — PR-A Task A.1
+    # In-flight guard API — PR-A Task A.1 + production acquire/release.
+    # Scheduler calls acquire(request_id) when a request enters and
+    # release(request_id) when it exits (finished or aborted). The
+    # underlying set makes both operations idempotent so double-calls
+    # and unknown-id releases are safe.
     # -----------------------------------------------------------------
+    @property
+    def _in_flight_count(self) -> int:
+        """Derived view kept for test/backward-compat readers."""
+        with self._in_flight_lock:
+            return len(self._in_flight_ids)
+
+    def acquire(self, request_id: str) -> None:
+        """Record that `request_id` holds entries and blocks clear()."""
+        with self._in_flight_lock:
+            self._in_flight_ids.add(request_id)
+
+    def release(self, request_id: str) -> None:
+        """Release `request_id`'s hold. No-op if unknown (idempotent)."""
+        with self._in_flight_lock:
+            self._in_flight_ids.discard(request_id)
+
     def _mark_in_use_for_test(self) -> None:
-        """Bump the in-flight counter so `clear()` refuses.
+        """Bump the in-flight set with a synthetic id so `clear()` refuses.
 
-        Test-only affordance. Production wiring (scheduler-side acquire
-        on request enter / release on exit) is a follow-up; today this
-        guard is defense-in-depth behind PagedCacheManager's guard.
+        Test-only affordance. Each call adds a fresh synthetic id so
+        multiple invocations stack (matching the pre-acquire counter
+        behavior the existing tests rely on).
         """
-        self._in_flight_count += 1
+        import uuid as _uuid
+        self.acquire(f"_test_{_uuid.uuid4()}")
 
     def get_stats(self) -> dict[str, Any]:
         """Get cache statistics."""

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -12,6 +12,7 @@ This module provides two implementations:
 
 import copy
 import logging
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -113,12 +114,11 @@ class PrefixCacheManager:
         # Statistics
         self.stats = PrefixCacheStats()
 
-        # PR-A Task A.3: in-flight guard counter for clear() refusal.
-        # Defense-in-depth — PrefixCacheManager itself has no liveness
-        # tracking; production-side acquire/release wiring is a follow-up.
-        # Today the downstream PagedCacheManager guard is the authoritative
-        # one; this mirror keeps the contract uniform across cache tiers.
-        self._in_flight_count: int = 0
+        # In-flight guard for clear() — PR-A Task A.3 + acquire/release
+        # wiring for production. The set is canonical; _in_flight_count
+        # is a derived view kept for test/backward-compat readers.
+        self._in_flight_lock = threading.Lock()
+        self._in_flight_ids: set[str] = set()
 
     def _search(
         self, tokens: List[int]
@@ -366,33 +366,50 @@ class PrefixCacheManager:
             True if cache was wiped; False if refused because requests
             are in flight.
         """
-        num_in_use = self._in_flight_count
-        if num_in_use > 0:
-            logger.warning(
-                "[prefix-cache-admin] PrefixCacheManager.clear refused: "
-                "%d active requests. Drain traffic or wait for idle.",
-                num_in_use,
-            )
-            return False
+        with self._in_flight_lock:
+            num_in_use = len(self._in_flight_ids)
+            if num_in_use > 0:
+                logger.warning(
+                    "[prefix-cache-admin] PrefixCacheManager.clear refused: "
+                    "%d active requests. Drain traffic or wait for idle.",
+                    num_in_use,
+                )
+                return False
 
-        self._cache.clear()
-        self._lru.clear()
-        self.reset_stats()
-        logger.info("PrefixCacheManager cleared")
-        return True
+            self._cache.clear()
+            self._lru.clear()
+            self.reset_stats()
+            logger.info("PrefixCacheManager cleared")
+            return True
 
     # -----------------------------------------------------------------
-    # In-flight guard test helper — PR-A Task A.3
+    # In-flight guard API — PR-A Task A.3 + production acquire/release.
+    # See MemoryAwarePrefixCache.acquire/release for the sibling impl.
     # -----------------------------------------------------------------
+    @property
+    def _in_flight_count(self) -> int:
+        """Derived view kept for test/backward-compat readers."""
+        with self._in_flight_lock:
+            return len(self._in_flight_ids)
+
+    def acquire(self, request_id: str) -> None:
+        """Record that `request_id` is in flight and blocks clear()."""
+        with self._in_flight_lock:
+            self._in_flight_ids.add(request_id)
+
+    def release(self, request_id: str) -> None:
+        """Release `request_id`'s hold. No-op if unknown (idempotent)."""
+        with self._in_flight_lock:
+            self._in_flight_ids.discard(request_id)
+
     def _mark_in_use_for_test(self) -> None:
-        """Bump the in-flight counter so ``clear()`` refuses.
+        """Bump with a synthetic id so ``clear()`` refuses.
 
-        Test-only affordance. Production wiring (scheduler-side acquire
-        on request enter / release on exit) is a follow-up; today this
-        guard is defense-in-depth behind PagedCacheManager's guard.
-        Mirrors the A.1 helper on MemoryAwarePrefixCache.
+        Test-only affordance. Each call adds a fresh id so multiple
+        invocations stack, matching the pre-acquire counter behavior.
         """
-        self._in_flight_count += 1
+        import uuid as _uuid
+        self.acquire(f"_test_{_uuid.uuid4()}")
 
     def __len__(self) -> int:
         """Return number of cached entries."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2014,9 +2014,32 @@ class Scheduler:
         self.requests[request.request_id] = request
         self.waiting.append(request)
 
+        # Acquire the in-flight hold on the active defensive cache tier.
+        # Released in remove_finished_request / _do_abort_request. The paged
+        # and block-aware tiers have their own authoritative guards via block
+        # refcounts and don't need the acquire/release wiring.
+        self._acquire_cache_hold(request.request_id)
+
         logger.debug(
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
+
+    def _acquire_cache_hold(self, request_id: str) -> None:
+        """Acquire an in-flight hold on whichever defensive cache tier is
+        active. Idempotent. No-op when only the paged/block-aware tiers
+        are configured (they guard via block refcounts)."""
+        if self.memory_aware_cache is not None:
+            self.memory_aware_cache.acquire(request_id)
+        if self.prefix_cache is not None:
+            self.prefix_cache.acquire(request_id)
+
+    def _release_cache_hold(self, request_id: str) -> None:
+        """Release the in-flight hold. Idempotent — safe to call on unknown
+        or already-released request_ids."""
+        if self.memory_aware_cache is not None:
+            self.memory_aware_cache.release(request_id)
+        if self.prefix_cache is not None:
+            self.prefix_cache.release(request_id)
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -2087,6 +2110,7 @@ class Scheduler:
             request.set_finished(RequestStatus.FINISHED_ABORTED)
         self.finished_req_ids.add(request_id)
         self._cleanup_detokenizer(request_id)
+        self._release_cache_hold(request_id)
 
         # Flush Metal encoders after removing arrays from batch
         mx.clear_cache()
@@ -2720,6 +2744,7 @@ class Scheduler:
 
     def remove_finished_request(self, request_id: str) -> Optional[Request]:
         """Remove a finished request from tracking."""
+        self._release_cache_hold(request_id)
         return self.requests.pop(request_id, None)
 
     def get_running_requests_info(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

The A.1 / A.3 cache-clear guards landed in PR #16 but were defensive-only — the underlying counter was bumped only by \`_mark_in_use_for_test()\`. This PR wires the real production acquire/release lifecycle from the scheduler, so the guards actually fire when real requests are in flight.

**Concretely:**
- Replaces \`MemoryAwarePrefixCache._in_flight_count\` and \`PrefixCacheManager._in_flight_count\` with a set-backed \`_in_flight_ids: set[str]\` + \`threading.Lock()\`. The old integer is preserved as a derived \`@property\` for backward-compat readers. The test-helper \`_mark_in_use_for_test()\` now adds a synthetic UUID so repeat calls still stack.
- Adds \`acquire(request_id: str)\` and \`release(request_id: str)\` public API. Set semantics make both idempotent: double-acquire is a no-op, release-unknown is a no-op.
- Scheduler hooks:
  - \`add_request()\` → \`_acquire_cache_hold(request_id)\`
  - \`remove_finished_request()\` → \`_release_cache_hold(request_id)\`
  - \`_do_abort_request()\` → \`_release_cache_hold(request_id)\` (defensive; idempotent with the finish path)
- The helpers no-op on the paged/block-aware tier since \`PagedCacheManager\`'s block-refcount guard is already authoritative.

## Why this matters

Before this PR, if a scheduler was configured with \`use_memory_aware_cache=True\` or the legacy \`PrefixCacheManager\`, \`DELETE /v1/cache\` during live traffic would still clear — the defensive guard never saw the in-flight requests. Now all three clear-path tiers (memory-aware, legacy, paged) refuse consistently under load and return HTTP 409 via the endpoint adapter from PR #16.

## Test plan
- [x] 7 new unit tests on the cache classes (acquire/release idempotency, multi-request independence)
- [x] 5 new integration tests in \`tests/test_scheduler_cache_hold.py\` exercising the real scheduler lifecycle through mocked model/tokenizer: \`add_request\` → \`clear()\` refuses → \`remove_finished_request\` → \`clear()\` allowed; abort path; paged-cache no-op path
- [x] All 128 cache tests pass; full suite 1287 pass (pre-existing 12 async/torch failures unrelated)

## Commits
\`\`\`
df1ea07 feat(scheduler): wire acquire/release so cache-clear guards fire in production
a3aa97a feat(cache): acquire/release API on MemoryAwarePrefixCache + PrefixCacheManager
\`\`\`

Closes the \"defensive-only\" follow-up flagged in PR #16's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)