### PR TITLE
docs: add CHANGELOG + refresh README/effort-and-budget for fork features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+Fork-local changes on top of [waybarrios/vllm-mlx](https://github.com/waybarrios/vllm-mlx). Entries are grouped by feature area and sorted newest-first within each release bucket.
+
+The `Unreleased` section captures work that has merged to `main` but isn't tagged yet.
+
+Format: entries cite the PR number + a one-line summary. See the PR body for the full context. See [`UPSTREAM_PIN.md`](UPSTREAM_PIN.md) for the invariants that must survive an upstream rebase.
+
+---
+
+## Unreleased
+
+### Thinking budget — API correctness and observability
+
+- **#20** `fix(anthropic)`: wire `extract_reasoning` + `thinking_tokens` on non-streaming `/v1/messages`. Pre-fix, the non-streaming Anthropic path never split reasoning from content — the `type:"thinking"` content block (from #13) and its `signature` field (from #14) were dead code. Also adds `AnthropicUsage.thinking_tokens` (vllm-mlx extension) so operators can measure thinking depth without re-tokenizing.
+- **#14** `fix(anthropic)`: required `signature` field on thinking content blocks. Schema-conformant with the Anthropic SDK's `ThinkingBlock` model. Populated deterministically with `"vllm-mlx:" + sha256(thinking_text)[:32]`.
+
+### Response headers and diagnostics
+
+- **#15** `feat(server)`: `x-thinking-budget-noop-reason` header (5 enumerated values: `parser_not_configured`, `tokenizer_encode_failed`, `multi_token_delimiter`, `mllm_path`, `simple_engine`) + WARN when `max_tokens < max_tokens_floor`. The `noop-reason` header closes a diagnosability gap: operators no longer have to guess why `applied=false`.
+
+### Cache safety
+
+- **#19** `feat(cache)`: wire production `acquire(request_id)` / `release(request_id)` on `MemoryAwarePrefixCache` and `PrefixCacheManager`. Before this, the #16 guards existed but never fired under real load — only `_mark_in_use_for_test()` bumped the counter. Now all three clear-path tiers refuse consistently when requests are in flight.
+- **#16** `fix(cache)`: `DELETE /v1/cache` returns HTTP 409 when any tier refuses. Three cache tiers (`memory_aware_cache`, `block_aware_cache`, `prefix_cache`) gained matching in-flight guards. Also fixed a pre-clear ordering bug in `BlockAwarePrefixCache` that could leave partial corruption on delegate refusal.
+
+### Resolver hardening
+
+- **#17** `fix(effort)`: resolver hardening. Exports `ALLOWED_EFFORT_LEVELS` as single source of truth for validators. Pydantic `field_validator` on `reasoning_effort`, `output_config.effort`, and `thinking.budget_tokens` rejects malformed input at HTTP 422 instead of silently falling through to DEFAULT. WARNs on non-empty `thinking` dict missing `type`. Caps the `max` effort floor at 32768 with prompt headroom (down from 131072 on 1M-ctx models).
+
+### Test coverage
+
+- **#18** `test`: adapter scheduler-walking chain + cross-dialect parity matrix (M-9 fix). Parity test now requires every dialect to emit thinking > 0 — pre-fix `count == 0 or ratio_ok` could mask 2/4 dialects silently dropping to zero.
+
+### Provider dialect unification
+
+- **#13** `feat`: provider effort/budget unification. New `vllm_mlx/api/effort.py` resolver collapses 5 provider-dialect signals (top-level `thinking_token_budget`, Anthropic `thinking.type` disabled/enabled/adaptive, `output_config.effort`, OpenAI `reasoning_effort`) into one `ResolvedBudget`. Emits 3 new response headers (`x-thinking-budget-resolved`, `x-thinking-budget-source`, `x-thinking-budget-max-tokens-floor`). Extends `DELETE /v1/cache` + `GET /v1/cache/stats` to cover `MemoryAwarePrefixCache`. Non-streaming `/v1/messages` now emits `type:"thinking"` content blocks (completed by #20 which wired `extract_reasoning`).
+
+### Sizing guardrail
+
+- **#12** `feat(server)`: WARN when `thinking_token_budget >= max_tokens`. Catches the common truncation mistake where clients set `effort=high` but leave `max_tokens` at the SDK default.
+
+### `mlx_lm` 0.31.x compatibility
+
+- **#8** `fix`: `mlx_lm` 0.31.2+ `BatchGenerator.active_batch` drift (hard-cut). The `active_batch` attribute was removed; scheduler now walks `_prompt_batch` + `_generation_batch` via `_active_batches(bg)` helper. Includes AST sentinel so a rebase that reintroduces `active_batch` fails loudly. Adds `UPSTREAM_PIN.md` invariant #10 + one-shot breadcrumb. Fixes crash-every-step on Qwen3-0.6B observed after mlx_lm upgrade.
+- **#7** `fix(thinking-budget)`: `tokens` arg is generated-only in `mlx_lm` 0.31+. Drops the `prompt_len` slice in the logits processor that was correct for 0.30.x but over-slices on 0.31+.
+- **#3** `fix`: tolerate `mlx_lm` 0.31+ API drift (`Batch` split + `BatchGenerator.next` tuple). Chunked prefill becomes a no-op on unsupported versions.
+
+### Reasoning parsers
+
+- **#10** `fix(thinking-budget)`: `budget=0` enforcement with prompt-injected `<think>`. Qwen3.6's chat template pre-injects `<think>` into the assistant turn, which tripped a state-machine ordering bug in the logits processor — `_end_count` was consumed on the model's freely-sampled first token. Fix: `_end_count` management moved to `__call__`, advanced in lockstep with the force bias.
+- **Q1 fix (55d25cf)** `fix(qwen3-parser)`: surface truncated `<think>` as reasoning, not content. When `max_tokens` cuts generation before `</think>`, the parser now returns `(reasoning_before_cut, None)` instead of `(None, content_with_<think>_tag)`.
+- **#1** `fix`: Gemma 4 broken streaming text in Anthropic Messages API.
+
+### Thinking token budget (feature)
+
+- **#2** `feat`: `thinking_token_budget` for the text path — port of vLLM #20859. Per-request logits processor that force-biases the `</think>` token's logit to `+1e9` once the budget is hit. Works where start/end delimiters tokenize to single tokens (Qwen3, DeepSeek-R1). Multi-token delimiter families (Gemma 4 channel protocol, GPT-OSS Harmony) are a loud no-op.
+
+### Documentation
+
+- **#11** `docs`: answer-quality validation — OFF still correct on multi-step + CRT problems.
+- **#9** `docs`: post-merge validation of `active_batch` drift fix.
+- **#6** `test`: HTTP matrix for `thinking_token_budget` across model families.
+- **#5** `docs`: MLLM extension playbook for `thinking_token_budget`.
+- **#4** `docs`: mark Quirk #1 as fixed; correct `_find_last_subsequence` perf note.
+- `docs`: add vllm-mlx vs upstream vLLM relationship + capabilities reference (b9e9343).
+
+---
+
+## Contributing to this file
+
+When you merge a PR to `main`, add a one-line entry under `Unreleased` in the appropriate section. Keep it to the PR number + a summary of *what changed* and *why it matters* (not "what we did"). When we cut a release, move everything under `Unreleased` into a new `## X.Y.Z (date)` section.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# vLLM-MLX
+# vLLM-MLX (patched fork)
 
 **vLLM-like inference for Apple Silicon** - GPU-accelerated Text, Image, Video & Audio on Mac
+
+> **This is a patched fork** of [waybarrios/vllm-mlx](https://github.com/waybarrios/vllm-mlx) tracked at [`jackneil/vllm-mlx-patched`](https://github.com/jackneil/vllm-mlx-patched). It adds per-request thinking-token budgets, provider-dialect effort unification, cache-safety guards, and assorted `mlx_lm` 0.31.x compatibility fixes. See [`CHANGELOG.md`](CHANGELOG.md) for the full diff vs. upstream and [`UPSTREAM_PIN.md`](UPSTREAM_PIN.md) for the invariants that must survive a rebase.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apple Silicon](https://img.shields.io/badge/Apple-Silicon-black.svg)](https://support.apple.com/en-us/HT211814)
-[![GitHub](https://img.shields.io/badge/GitHub-waybarrios%2Fvllm--mlx-blue?logo=github)](https://github.com/waybarrios/vllm-mlx)
+[![GitHub](https://img.shields.io/badge/GitHub-jackneil%2Fvllm--mlx--patched-blue?logo=github)](https://github.com/jackneil/vllm-mlx-patched)
 
 ## Overview
 
@@ -26,8 +28,9 @@ vllm-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
 - **Anthropic Messages API** - native `/v1/messages` endpoint for Claude Code and OpenCode
 - **Embeddings** - OpenAI-compatible `/v1/embeddings` endpoint with mlx-embeddings
 - **Reasoning Models** - extract thinking process from Qwen3, DeepSeek-R1
+- **Thinking Token Budget** (fork) - per-request caps via `thinking_token_budget`, `reasoning_effort`, `output_config.effort`, or Anthropic `thinking.type` — see [Effort & Thinking Budget](docs/guides/effort-and-budget.md)
 - **MCP Tool Calling** - integrate external tools via Model Context Protocol
-- **Paged KV Cache** - memory-efficient caching with prefix sharing
+- **Paged KV Cache** - memory-efficient caching with prefix sharing + in-flight guards (fork: `DELETE /v1/cache` returns HTTP 409 under load instead of crashing the generation loop)
 - **Continuous Batching** - high throughput for multiple concurrent users
 
 ## Quick Start
@@ -224,8 +227,13 @@ For full documentation, see the [docs](docs/) directory:
   - [Audio (STT/TTS)](docs/guides/audio.md)
   - [Embeddings](docs/guides/embeddings.md)
   - [Reasoning Models](docs/guides/reasoning.md)
+  - [Effort & Thinking Budget](docs/guides/effort-and-budget.md) *(fork)*
   - [MCP & Tool Calling](docs/guides/mcp-tools.md)
   - [Continuous Batching](docs/guides/continuous-batching.md)
+
+- **Fork-specific**
+  - [Changelog](CHANGELOG.md)
+  - [Upstream Pin + Invariants](UPSTREAM_PIN.md)
 
 - **Reference**
   - [CLI Commands](docs/reference/cli.md)
@@ -371,7 +379,7 @@ We welcome contributions! See [Contributing Guide](docs/development/contributing
 - Documentation improvements
 - Benchmarks on different Apple Silicon chips
 
-Submit PRs to: [https://github.com/waybarrios/vllm-mlx](https://github.com/waybarrios/vllm-mlx)
+Submit PRs against this fork at [https://github.com/jackneil/vllm-mlx-patched](https://github.com/jackneil/vllm-mlx-patched). Changes that aren't fork-specific are ideally also sent upstream to [waybarrios/vllm-mlx](https://github.com/waybarrios/vllm-mlx) so everyone benefits.
 
 ## License
 

--- a/docs/guides/effort-and-budget.md
+++ b/docs/guides/effort-and-budget.md
@@ -47,21 +47,35 @@ Every response that went through the resolver emits these headers:
 | `x-thinking-budget-resolved` | int as string, or `"none"` | The resolver's output — what the server actually tried to enforce. |
 | `x-thinking-budget-source` | `top_level` \| `anthropic_thinking_enabled` \| `anthropic_thinking_disabled` \| `anthropic_thinking_adaptive` \| `output_config_effort` \| `reasoning_effort` \| `default` | Which input field won precedence. |
 | `x-thinking-budget-max-tokens-floor` | int as string | Recommended minimum `max_tokens` for this effort level. Absent when source is `default` or budget is 0. |
-| `x-thinking-budget-noop-reason` | string (e.g., `channel_protocol_not_supported`) | Explains why `applied=false`. Only present when applied=false. |
+| `x-thinking-budget-noop-reason` | `parser_not_configured` \| `tokenizer_encode_failed` \| `multi_token_delimiter` \| `mllm_path` \| `simple_engine` | Machine-readable reason the processor didn't attach. Only present when `applied=false`. See **Noop reasons** below. |
 
 ## Per-family enforceability
 
-Not every model family can enforce the budget. The logits processor biases the `</think>` token's logit when the budget is hit — this only works if `</think>` tokenizes to a single token.
+Not every model family can enforce the budget. The logits processor biases the `</think>` token's logit when the budget is hit — this only works if `</think>` tokenizes to a single token AND the engine runs logits processors at all.
 
-| Family | Thinking protocol | Enforceable? |
+| Family | Thinking protocol | Enforceable? | Typical noop reason |
+|---|---|---|---|
+| Qwen3 / Qwen3.5 / Qwen3.6 | `<think>…</think>` (single token) | ✓ | — |
+| DeepSeek-R1 | `<think>…</think>` | ✓ | — |
+| Generic models with `think_parser` | `<think>…</think>` | ✓ | — |
+| Gemma 4 | channel protocol, also auto-detected as MLLM | ✗ — loud noop | `mllm_path` |
+| GPT-OSS / Harmony | channel protocol (multi-token) | ✗ — loud noop | `multi_token_delimiter` |
+
+When enforcement fails, the request still succeeds — the server generates normally and reports `applied=false` + the reason header. Nothing silent.
+
+## Noop reasons
+
+| Value | What it means | How to fix |
 |---|---|---|
-| Qwen3 / Qwen3.5 / Qwen3.6 | `<think>…</think>` (single token) | ✓ |
-| DeepSeek-R1 | `<think>…</think>` | ✓ |
-| Generic models with `think_parser` | `<think>…</think>` | ✓ |
-| Gemma 4 | channel protocol (multi-token) | ✗ — loud noop |
-| GPT-OSS / Harmony | channel protocol | ✗ — loud noop |
+| `parser_not_configured` | Server started without `--reasoning-parser`. | Restart the server with e.g. `--reasoning-parser qwen3`. |
+| `tokenizer_encode_failed` | The parser's `start_token` / `end_tokens` raised when encoded, or returned an empty list. | Usually means the parser is mismatched with the tokenizer. Check parser/model compatibility. |
+| `multi_token_delimiter` | Delimiters exist but encode to >1 token — the force-bias logic only hits single-token `</think>`. | Inherent to the model family. No fix; choose a family with single-token delimiters or accept unbounded thinking. |
+| `mllm_path` | Request went through the multimodal path, which skips logits processors entirely. | Inherent to the path. For text-only requests you can force the LLM path if the model supports it; otherwise accept unbounded thinking. |
+| `simple_engine` | Server is running in SimpleEngine mode, which doesn't support logits processors. | Restart the server with `--continuous-batching`. This is the most common misconfiguration. |
 
-When a model family cannot enforce, the server attaches the processor anyway (so `applied=false` is a legitimate signal rather than a silent failure), emits `x-thinking-budget-noop-reason`, and generates normally. The request succeeds with no cap applied.
+## `AnthropicUsage.thinking_tokens` (vllm-mlx extension)
+
+Non-streaming `/v1/messages` responses include a `usage.thinking_tokens` field carrying the token count of the reasoning portion alone (Anthropic's public API only surfaces a single `output_tokens`). `None` (excluded from JSON) when no reasoning was produced. Best-effort — computed by tokenizing the extracted reasoning text with the reasoning parser's tokenizer; a tokenizer failure logs a WARNING and leaves the field as `None`. Streaming does not yet emit this field.
 
 ## Examples
 
@@ -114,3 +128,5 @@ or (Anthropic only)
 When setting a non-zero budget, ensure `max_tokens >= thinking_token_budget + content_headroom` (roughly `budget + 1000` for typical chat responses). If `max_tokens` is too tight, the model hits `max_tokens` while still inside `<think>` and the caller sees `finish_reason: "length"` with an empty or truncated content block.
 
 Clients can trust `x-thinking-budget-max-tokens-floor` as a floor — it is always at least `budget + content_headroom`.
+
+The server logs a WARNING with prefix `[thinking-budget-resolver]` when `max_tokens < max_tokens_floor` at request ingress, naming the effort level, the floor, and the received `max_tokens` — grep operator logs for this marker when debugging truncated output on `effort=high` requests.


### PR DESCRIPTION
## Summary

Doc drift audit triggered by "we've shipped 9+ PRs in 2 days with no changelog, and the README points at the upstream repo." Three fixes:

1. **New `CHANGELOG.md`** — backfills the thinking-budget arc (#1 → #20), organized by area (Thinking budget API correctness, Response headers, Cache safety, Resolver hardening, Test coverage, Provider-dialect unification, Sizing guardrail, mlx_lm compat, Reasoning parsers, Documentation). Adds a "Contributing to this file" note so future PRs append entries under `Unreleased`.

2. **`docs/guides/effort-and-budget.md` refresh**:
   - Header example value was `channel_protocol_not_supported` — not one of the 5 values we actually emit. Replaced with the enumerated list.
   - New "Noop reasons" table with the operator fix for each (the `simple_engine` row explains the exact case that burned an arena session for two sittings — "run the server with `--continuous-batching`").
   - Gemma 4 row corrected: actual noop reason is `mllm_path`, not multi-token delimiter (MLLM auto-detection bypasses logits processors before the delimiter check fires).
   - Documented `AnthropicUsage.thinking_tokens` (vllm-mlx extension from #20).
   - Mention of the `[thinking-budget-resolver]` WARN on `max_tokens < max_tokens_floor`.

3. **`README.md`**:
   - Identify as the `jackneil/vllm-mlx-patched` fork with CHANGELOG + UPSTREAM_PIN links.
   - GitHub badge flipped to the patched fork URL.
   - Features list gets thinking-token-budget and cache-guard rows (both marked "(fork)").
   - Docs index links Effort & Thinking Budget guide; new "Fork-specific" subsection.
   - "Submit PRs to" pointed at upstream (which would reject fork-specific work). Now points at the fork, with a note to also upstream non-fork-specific fixes.

## Test plan
- [x] Read both updated docs end-to-end for consistency
- [x] Verified noop-reason enum values against `vllm_mlx/request.py:162-169`
- [x] Verified \`simple_engine\` fix advice matches today's live verification against port 18004
- [ ] Render README on GitHub after merge to confirm links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)