### PR TITLE
fix: KV cache LCP contamination producing garbage output (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: entries cite the PR number + a one-line summary. See the PR body for the
 
 ## Unreleased
 
+### KV cache LCP contamination fix (issue #29)
+
+- **Fix `--continuous-batching` producing garbage on request 2+** ([#29](https://github.com/jackneil/vllm-mlx-patched/issues/29)) — sessions that loaded a persisted prefix cache could return degenerate repetitive output (`ongo`, `diễn`, ...) for the second and later requests. Root cause was twofold:
+  1. `_trim_cache_offset` and `_dequantize_cache` returned caches that shrank `.offset` but reused the over-sized source `keys`/`values` arrays. Attention paths that read `cache.state` directly (Gemma 4 KV-shared layers upstream, Qwen3 kickoff on supersequence matches in our fork) saw stale tokens from the previous owner of the buffer.
+  2. Disk-persisted entries from older fork versions had no consistency gate at load time.
+- Ports `waybarrios/vllm-mlx#385` (`9630c5d`, array-slice fix) and `waybarrios/vllm-mlx#365` (`01261c1`, persist-format v3 + model fingerprint). Existing caches at `~/.cache/vllm-mlx/prefix_cache/` auto-discarded and rebuilt on the next server start.
+- Regression coverage: `tests/test_memory_cache_mlx.py` (MLX-backed slice tests), `tests/test_memory_cache.py` (fingerprint helper + load gate), `tests/test_issue_29_end_to_end.py` (end-to-end lockdown).
+
 ### Qwen3 first-turn runaway mitigation
 
 - **Qwen3 first-turn runaway — three-layer defense shipped.** Qwen3.x models on first-turn-with-tools requests can enter an "interleaved thinking" trap — generating reasoning indefinitely without emitting `</think>`. Mitigations:

--- a/UPSTREAM_PIN.md
+++ b/UPSTREAM_PIN.md
@@ -178,6 +178,59 @@ Test guard: `tests/test_chat_template_kwargs_plumbing.py`. If ANY of the server�
 
 Additionally, `server._reasoning_parser_name` is a module attribute set from `args.reasoning_parser` at CLI bind time (`cli.py:~63-85`). Layer 1 reads this — NOT `engine._reasoning_parser_name` (which does not exist) — because Layer 1 needs the raw CLI string like `"qwen3"`, not the class instance on `server._reasoning_parser`.
 
+### Added 2026-04-21: issue #29 KV cache LCP contamination fix
+
+**Ported from `waybarrios/vllm-mlx`:**
+
+- `9630c5d` (#385, 2026-04-21) — `_trim_cache_offset` KVCache slice +
+  `_dequantize_cache` slice. Fixes stale-tokens-past-offset leak visible as
+  `ongo/diễn` garbage on Qwen3-0.6B supersequence-match kickoff and as
+  content bleed on Gemma 4 KV-shared layers upstream.
+
+- `01261c1` (#365, 2026-04-17) — `_CACHE_PERSIST_VERSION = 3` +
+  `_compute_model_fingerprint` + load-time gate. Discards pre-fix disk
+  caches that would otherwise contaminate a fresh session.
+
+Our fork's `_trim_cache_offset` has a different branch structure from
+upstream: upstream uses a `_QuantizedCacheWrapper`; we dispatch on the real
+`QuantizedKVCache` class. The plain-KVCache slice logic was ported
+verbatim; the QuantizedKVCache-specific slice in upstream's
+`_trim_cache_offset` is not applicable to our structure but we have a
+parallel slice in `_dequantize_cache` that covers the same leak.
+
+Additional discovery: RotatingKVCache falls into our KVCache branch of
+`_trim_cache_offset` (it has `.offset` and array `.keys`), so the slice
+fix covers it — but the returned wrapper is a plain `KVCache`, losing
+Rotating-specific attrs (`max_size`, `keep`, `_idx`). Pre-existing
+behaviour, not introduced here, locked down by a regression test at
+`tests/test_memory_cache_mlx.py::TestTrimCacheOffset::test_rotating_kv_cache_slice_applies_but_type_stripped`.
+
+**Deliberately NOT ported** (follow-up PR, not required for #29):
+
+- `09cc64e`, `b61f57c` (#296) — RotatingKVCache proper handling.
+- `d38b978` (#286) — 3D KV tensors in `prefix_cache.py` (paged/block-aware
+  tier; not active on text path that #29 exercised).
+- `5d93852` (#217) — hybrid recurrent state across blocks.
+
+### Invariant 15: `_trim_cache_offset` slices arrays to new offset (added 2026-04-21)
+
+`memory_cache._trim_cache_offset` MUST slice the `keys`/`values` arrays
+down to `new_offset` when returning a trimmed KVCache wrapper, not just
+shrink `.offset`. Sharing the oversized source array across requests
+exposes stale tokens to paths that read `cache.state` directly (Gemma 4
+KV-shared layers, Qwen3 kickoff on supersequence matches — issue #29).
+Pinned by `tests/test_memory_cache_mlx.py`.
+
+### Invariant 16: disk cache gated on version+fingerprint (added 2026-04-21)
+
+`memory_cache.MemoryAwarePrefixCache.save_to_disk` MUST record
+`_CACHE_PERSIST_VERSION` (currently 3) and `_compute_model_fingerprint`
+in the index. `load_from_disk` MUST reject entries whose version differs
+from current OR whose fingerprint differs from the current model's. This
+prevents pre-fix entries from silently contaminating a session. Pinned
+by `tests/test_memory_cache.py::test_load_rejects_older_version` and
+`test_load_rejects_fingerprint_mismatch`.
+
 ## Rebase checklist
 
 When merging upstream changes into this fork:

--- a/tests/test_issue_29_end_to_end.py
+++ b/tests/test_issue_29_end_to_end.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end regression for jackneil/vllm-mlx-patched#29.
+
+Symptom: three sequential chat requests against a server that loaded a
+persisted MemoryAwarePrefixCache produced coherent output on request 1
+and degenerate token-loop garbage ('ongo', 'diễn', ...) on requests
+2+. Root cause: LCP / supersequence matches returned a cache whose
+arrays still contained data past the trimmed offset; the kickoff
+prefill exposed that stale data to attention.
+"""
+
+from unittest.mock import MagicMock
+
+
+def test_issue_29_supersequence_fetch_no_stale_kv():
+    """Shape of the #29 bug: stored supersequence entry with private data
+    past the shared prefix. Fetch on the shared prefix must not expose
+    the private data via cache.state or the underlying array shape.
+    """
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    model = MagicMock()
+    model.config = MagicMock(
+        num_hidden_layers=2,
+        hidden_size=64,
+        vocab_size=100,
+        num_key_value_heads=2,
+        head_dim=32,
+        intermediate_size=128,
+        model_type="qwen3",
+    )
+    pc = MemoryAwarePrefixCache(
+        model, MemoryCacheConfig(max_memory_mb=8, max_entries=4)
+    )
+
+    layers = []
+    for _ in range(2):
+        shared = mx.ones((1, 2, 14, 32), dtype=mx.float32)
+        private = mx.full((1, 2, 80, 32), 7.0, dtype=mx.float32)
+        layer = KVCache()
+        layer.keys = mx.concatenate([shared, private], axis=2)
+        layer.values = mx.concatenate([shared, private], axis=2)
+        layer.offset = 94
+        layers.append(layer)
+
+    pc.store(list(range(1, 95)), layers)
+
+    fetched, remaining = pc.fetch(list(range(1, 15)))
+
+    assert fetched is not None
+    for layer in fetched:
+        keys_view, values_view = layer.state
+        assert keys_view.shape[-2] == 14
+        assert values_view.shape[-2] == 14
+        assert float(mx.max(keys_view).item()) == 1.0
+        assert float(mx.max(values_view).item()) == 1.0
+    assert remaining == []
+
+
+def test_issue_29_pre_fix_persisted_cache_is_discarded(tmp_path):
+    """A persisted cache written at version=2 (pre-fix) must be
+    discarded on load so pre-fix entries cannot contaminate a fresh run.
+    """
+    import json
+
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    d = tmp_path
+    (d / "index.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "num_entries": 5,
+                "entries": [
+                    {"index": i, "num_tokens": 50 + i} for i in range(5)
+                ],
+            }
+        )
+    )
+
+    model = MagicMock()
+    model.config = MagicMock(num_hidden_layers=28)
+    pc = MemoryAwarePrefixCache(model, MemoryCacheConfig(max_memory_mb=8))
+
+    assert pc.load_from_disk(str(d)) == 0

--- a/tests/test_issue_29_end_to_end.py
+++ b/tests/test_issue_29_end_to_end.py
@@ -74,9 +74,7 @@ def test_issue_29_pre_fix_persisted_cache_is_discarded(tmp_path):
             {
                 "version": 2,
                 "num_entries": 5,
-                "entries": [
-                    {"index": i, "num_tokens": 50 + i} for i in range(5)
-                ],
+                "entries": [{"index": i, "num_tokens": 50 + i} for i in range(5)],
             }
         )
     )

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -552,3 +552,47 @@ def test_acquire_release_multiple_requests_independent():
 
     cache.release("req-B")
     assert cache.clear() is True
+
+
+def test_compute_model_fingerprint_is_deterministic_and_config_sensitive():
+    """#29 — fingerprint helper must (1) round-trip identically for the same
+    config and (2) differ when any of the load-bearing config attrs change.
+    """
+    from vllm_mlx.memory_cache import _compute_model_fingerprint
+
+    def _mk(**overrides):
+        cfg = MagicMock()
+        defaults = dict(
+            num_hidden_layers=28,
+            hidden_size=1024,
+            vocab_size=151936,
+            num_key_value_heads=8,
+            head_dim=128,
+            intermediate_size=3072,
+            model_type="qwen3",
+        )
+        defaults.update(overrides)
+        for k, v in defaults.items():
+            setattr(cfg, k, v)
+        m = MagicMock()
+        m.config = cfg
+        return m
+
+    base = _compute_model_fingerprint(_mk())
+    assert isinstance(base, str) and len(base) == 16
+    # Same config -> same fingerprint.
+    assert _compute_model_fingerprint(_mk()) == base
+    # Each of these MUST flip the fingerprint.
+    for field in (
+        "num_hidden_layers",
+        "hidden_size",
+        "vocab_size",
+        "num_key_value_heads",
+        "head_dim",
+        "intermediate_size",
+        "model_type",
+    ):
+        other_val = "xxx" if field == "model_type" else 9999
+        assert _compute_model_fingerprint(_mk(**{field: other_val})) != base, (
+            f"fingerprint should differ when {field} changes"
+        )

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -593,9 +593,9 @@ def test_compute_model_fingerprint_is_deterministic_and_config_sensitive():
         "model_type",
     ):
         other_val = "xxx" if field == "model_type" else 9999
-        assert _compute_model_fingerprint(_mk(**{field: other_val})) != base, (
-            f"fingerprint should differ when {field} changes"
-        )
+        assert (
+            _compute_model_fingerprint(_mk(**{field: other_val})) != base
+        ), f"fingerprint should differ when {field} changes"
 
 
 def test_save_then_load_roundtrip_with_fingerprint(tmp_path):

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -596,3 +596,85 @@ def test_compute_model_fingerprint_is_deterministic_and_config_sensitive():
         assert _compute_model_fingerprint(_mk(**{field: other_val})) != base, (
             f"fingerprint should differ when {field} changes"
         )
+
+
+def test_save_then_load_roundtrip_with_fingerprint(tmp_path):
+    """#29 — save-then-load roundtrip on an empty cache must succeed
+    (returns False for save-nothing, 0 for load-nothing) and must not
+    crash from the new version/fingerprint plumbing.
+    """
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    model = MagicMock()
+    model.config = MagicMock(
+        num_hidden_layers=28,
+        hidden_size=1024,
+        vocab_size=151936,
+        num_key_value_heads=8,
+        head_dim=128,
+        intermediate_size=3072,
+        model_type="qwen3",
+    )
+    cache = MemoryAwarePrefixCache(
+        model, MemoryCacheConfig(max_memory_mb=8, max_entries=4)
+    )
+
+    d = str(tmp_path)
+    assert cache.save_to_disk(d) is False
+    assert cache.load_from_disk(d) == 0
+
+
+def test_load_rejects_older_version(tmp_path):
+    """#29 — a cache written with version<3 must be discarded on load."""
+    import json
+
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    d = tmp_path
+    (d / "index.json").write_text(
+        json.dumps({"version": 2, "num_entries": 3, "entries": []})
+    )
+
+    model = MagicMock()
+    model.config = MagicMock(num_hidden_layers=1)
+    cache = MemoryAwarePrefixCache(model, MemoryCacheConfig(max_memory_mb=8))
+
+    assert cache.load_from_disk(str(d)) == 0
+
+
+def test_load_rejects_fingerprint_mismatch(tmp_path):
+    """#29 — a v3 cache whose fingerprint differs from current model's
+    must be rejected.
+    """
+    import json
+
+    from vllm_mlx.memory_cache import (
+        _CACHE_PERSIST_VERSION,
+        MemoryAwarePrefixCache,
+        MemoryCacheConfig,
+    )
+
+    d = tmp_path
+    (d / "index.json").write_text(
+        json.dumps(
+            {
+                "version": _CACHE_PERSIST_VERSION,
+                "model_fingerprint": "deadbeefdeadbeef",
+                "num_entries": 0,
+                "entries": [],
+            }
+        )
+    )
+
+    model = MagicMock()
+    model.config = MagicMock(
+        num_hidden_layers=28,
+        hidden_size=1024,
+        vocab_size=151936,
+        num_key_value_heads=8,
+        head_dim=128,
+        intermediate_size=3072,
+        model_type="qwen3",
+    )
+    cache = MemoryAwarePrefixCache(model, MemoryCacheConfig(max_memory_mb=8))
+    assert cache.load_from_disk(str(d)) == 0

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -37,3 +37,30 @@ class TestTrimCacheOffset:
         assert tc.offset == 60
         assert tc.keys.shape[-2] == 60
         assert tc.values.shape[-2] == 60
+
+    def test_quantized_kv_cache_offset_shrinks(self):
+        """Regression guard for the QuantizedKVCache branch of
+        _trim_cache_offset. Our fork's branch shrinks offset correctly
+        and preserves group_size/bits. The dequantize-time slice in a
+        later commit depends on this invariant being stable.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache, QuantizedKVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        base = KVCache()
+        base.keys = mx.ones((1, 4, 128, 64), dtype=mx.float32)
+        base.values = mx.ones((1, 4, 128, 64), dtype=mx.float32)
+        base.offset = 128
+        qcache = base.to_quantized(group_size=64, bits=8)
+
+        trimmed = _trim_cache_offset([qcache], 68)
+        tc = trimmed[0]
+
+        assert isinstance(tc, QuantizedKVCache)
+        assert tc.offset == 60
+        assert tc.group_size == qcache.group_size
+        assert tc.bits == qcache.bits
+        # Source entry untouched.
+        assert qcache.offset == 128

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -64,3 +64,80 @@ class TestTrimCacheOffset:
         assert tc.bits == qcache.bits
         # Source entry untouched.
         assert qcache.offset == 128
+
+
+class TestDequantizeCacheSlice:
+    """Regression tests for _dequantize_cache slicing after dequantization.
+
+    When KV quantization is enabled, the prefix cache stores
+    QuantizedKVCache layers. After LCP trim reduces the offset,
+    _dequantize_cache must slice the dequantized arrays down to offset
+    to prevent readers that bypass offset from seeing stale tokens.
+    Mirrors the plain-KVCache slice in _trim_cache_offset.
+    """
+
+    def test_dequantize_slices_to_offset(self):
+        """After trim + dequantize, keys/values shape[-2] == offset."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _dequantize_cache, _trim_cache_offset
+
+        base = KVCache()
+        base.keys = mx.ones((1, 4, 512, 64), dtype=mx.float32)
+        base.values = mx.ones((1, 4, 512, 64), dtype=mx.float32)
+        base.offset = 512
+
+        qcache = base.to_quantized(group_size=64, bits=8)
+        trimmed = _trim_cache_offset([qcache], 512 - 60)
+        result = _dequantize_cache(trimmed)
+
+        tc = result[0]
+        assert tc.offset == 60
+        assert tc.keys.shape[-2] == 60
+        assert tc.values.shape[-2] == 60
+
+    def test_dequantize_no_stale_tokens_via_state(self):
+        """Stale tokens past offset must not be visible via cache.state."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _dequantize_cache, _trim_cache_offset
+
+        base = KVCache()
+        shared = mx.ones((1, 4, 64, 64), dtype=mx.float32)
+        private = mx.full((1, 4, 448, 64), 7.0, dtype=mx.float32)
+        base.keys = mx.concatenate([shared, private], axis=2)
+        base.values = mx.concatenate([shared, private], axis=2)
+        base.offset = 512
+
+        qcache = base.to_quantized(group_size=64, bits=8)
+        trimmed = _trim_cache_offset([qcache], 512 - 64)
+        result = _dequantize_cache(trimmed)
+
+        tc = result[0]
+        keys_view, _ = tc.state
+        assert keys_view.shape[-2] == 64
+        # Dequantized values are approximate; must stay near 1.0 (shared),
+        # never near 7.0 (private past offset).
+        assert float(mx.max(keys_view).item()) < 2.0
+
+    def test_dequantize_no_trim_preserves_full_array(self):
+        """When offset == shape[-2], no slicing occurs."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _dequantize_cache
+
+        base = KVCache()
+        base.keys = mx.ones((1, 4, 128, 64), dtype=mx.float32)
+        base.values = mx.ones((1, 4, 128, 64), dtype=mx.float32)
+        base.offset = 128
+
+        qcache = base.to_quantized(group_size=64, bits=8)
+        result = _dequantize_cache([qcache])
+
+        tc = result[0]
+        assert tc.offset == 128
+        assert tc.keys.shape[-2] == 128
+        assert tc.values.shape[-2] == 128

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-dependent regression tests for the KV cache LCP contamination fix.
+
+Ported from waybarrios/vllm-mlx#385. These tests use real
+mlx_lm.models.cache.KVCache objects backed by mlx.core arrays and
+therefore run only on Apple Silicon. The Linux test-matrix CI job
+excludes this file because MLX has no Linux distribution.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestTrimCacheOffset:
+    """Regression: LCP / supersequence trim used to shrink .offset while
+    sharing the oversized arrays, letting attention paths that read
+    cache.state directly (Gemma 4 KV-shared, Qwen3 kickoff) see stale
+    tokens from a prior owner. See waybarrios#384 and jackneil#29.
+    """
+
+    def test_plain_kv_cache_array_sliced_to_new_offset(self):
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        layer.keys = mx.arange(1 * 4 * 500 * 8, dtype=mx.float32).reshape(1, 4, 500, 8)
+        layer.values = mx.arange(1 * 4 * 500 * 8, dtype=mx.float32).reshape(
+            1, 4, 500, 8
+        )
+        layer.offset = 500
+
+        trim_by = 500 - 60
+        trimmed = _trim_cache_offset([layer], trim_by)
+        tc = trimmed[0]
+
+        assert tc.offset == 60
+        assert tc.keys.shape[-2] == 60
+        assert tc.values.shape[-2] == 60

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -103,6 +103,41 @@ class TestTrimCacheOffset:
         assert stored_layer.keys.shape[-2] == 120
         assert stored_layer.offset == 120
 
+    def test_rotating_kv_cache_slice_applies_but_type_stripped(self):
+        """RotatingKVCache has ``.offset`` and array-typed ``.keys`` so it
+        enters the KVCache branch of ``_trim_cache_offset`` (not the
+        catch-all else). The slice fix from #29 therefore applies — no
+        stale tokens past the trimmed offset — but a separate pre-existing
+        quirk is that the returned wrapper is a plain ``KVCache`` rather
+        than a ``RotatingKVCache``. Locking that in here so a future
+        refactor either preserves the type (fixing the pre-existing loss)
+        or fails this test loudly.
+
+        Tracking for proper RotatingKVCache handling (max_size / keep /
+        _idx preservation): follow-up PR, referencing
+        waybarrios/vllm-mlx#296 commit b61f57c.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = RotatingKVCache(max_size=128, keep=0)
+        layer.keys = mx.ones((1, 4, 128, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 128, 8), dtype=mx.float32)
+        layer.offset = 128
+
+        trimmed = _trim_cache_offset([layer], 50)
+        tc = trimmed[0]
+
+        # Slice fix applies: shape matches new offset (the #29 invariant).
+        assert tc.offset == 78
+        assert tc.keys.shape[-2] == 78
+        # Pre-existing quirk: type-stripped to plain KVCache. When
+        # waybarrios/vllm-mlx#296 is ported, this may change to preserve
+        # RotatingKVCache — at which point update this assertion.
+        assert isinstance(tc, KVCache)
+
 
 class TestDequantizeCacheSlice:
     """Regression tests for _dequantize_cache slicing after dequantization.

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -65,6 +65,44 @@ class TestTrimCacheOffset:
         # Source entry untouched.
         assert qcache.offset == 128
 
+    def test_fetch_returns_sliced_cache_on_lcp_match(self):
+        """End-to-end: MemoryAwarePrefixCache.fetch on a request that shares
+        only a prefix with a longer stored entry must return a cache whose
+        arrays are already sliced. This is the full regression of #29
+        above the unit level.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        model = MagicMock()
+        pc = MemoryAwarePrefixCache(
+            model, MemoryCacheConfig(max_memory_mb=64, max_entries=10)
+        )
+
+        stored_layer = KVCache()
+        shared = mx.ones((1, 2, 60, 4), dtype=mx.float32)
+        private = mx.full((1, 2, 60, 4), 7.0, dtype=mx.float32)
+        stored_layer.keys = mx.concatenate([shared, private], axis=2)
+        stored_layer.values = stored_layer.keys
+        stored_layer.offset = 120
+        pc.store(list(range(1, 121)), [stored_layer])
+
+        new_tokens = list(range(1, 60)) + [999, 1000, 1001]
+        fetched, remaining = pc.fetch(new_tokens)
+
+        assert fetched is not None
+        tc = fetched[0]
+        assert tc.offset == 59
+        assert tc.keys.shape[-2] == 59
+        # The 7.0 private content from the stored entry must NOT be visible.
+        assert float(mx.max(tc.keys).item()) == 1.0
+        assert remaining == [999, 1000, 1001]
+        # Source entry unaffected (fetched is a new wrapper over sliced arrays).
+        assert stored_layer.keys.shape[-2] == 120
+        assert stored_layer.offset == 120
+
 
 class TestDequantizeCacheSlice:
     """Regression tests for _dequantize_cache slicing after dequantization.

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -385,7 +385,15 @@ def _quantize_cache(cache: list[Any], bits: int = 8, group_size: int = 64) -> li
 
 
 def _dequantize_cache(cache: list[Any]) -> list[Any]:
-    """Dequantize QuantizedKVCache layers back to regular KVCache."""
+    """Dequantize QuantizedKVCache layers back to regular KVCache.
+
+    After dequantize, slice the keys/values down to ``offset`` so readers
+    that bypass ``offset`` (e.g. Gemma 4 KV-shared layers reading
+    cache.state directly, Qwen3 kickoff on supersequence matches) cannot
+    see stale tokens from a previous owner of the buffer. Mirrors the
+    plain-KVCache slice in ``_trim_cache_offset`` —
+    waybarrios/vllm-mlx#384, jackneil/vllm-mlx-patched#29.
+    """
     import mlx.core as mx
     from mlx_lm.models.cache import KVCache, QuantizedKVCache
 
@@ -400,6 +408,14 @@ def _dequantize_cache(cache: list[Any]) -> list[Any]:
                 *layer.values, group_size=layer.group_size, bits=layer.bits
             )
             kv.offset = layer.offset
+            if (
+                kv.keys is not None
+                and hasattr(kv.keys, "shape")
+                and len(kv.keys.shape) >= 3
+                and kv.offset < kv.keys.shape[-2]
+            ):
+                kv.keys = kv.keys[..., : kv.offset, :]
+                kv.values = kv.values[..., : kv.offset, :]
             result.append(kv)
         else:
             result.append(layer)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -288,9 +288,26 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
             and not isinstance(layer_cache.keys, (list, tuple))
         ):
             tc = KVCache.__new__(KVCache)
-            tc.keys = layer_cache.keys
-            tc.values = layer_cache.values
-            tc.offset = max(layer_cache.offset - trim_by, 0)
+            new_offset = max(layer_cache.offset - trim_by, 0)
+            keys = layer_cache.keys
+            values = layer_cache.values
+            # Slice arrays down to new_offset rather than shrinking only
+            # the offset pointer. Sharing the oversized array across
+            # requests exposes stale tokens to paths that read
+            # cache.state directly — waybarrios/vllm-mlx#384,
+            # jackneil/vllm-mlx-patched#29.
+            if (
+                keys is not None
+                and hasattr(keys, "shape")
+                and len(keys.shape) >= 3
+                and new_offset < keys.shape[-2]
+            ):
+                tc.keys = keys[..., :new_offset, :]
+                tc.values = values[..., :new_offset, :]
+            else:
+                tc.keys = keys
+                tc.values = values
+            tc.offset = new_offset
             trimmed.append(tc)
         else:
             trimmed.append(layer_cache)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -497,6 +497,7 @@ class MemoryAwarePrefixCache:
         """
         self._model_id = id(model)
         self._config = config or MemoryCacheConfig()
+        self._model_fingerprint = _compute_model_fingerprint(model)
 
         # OrderedDict maintains insertion order for LRU
         # Key: tuple(tokens), Value: _CacheEntry
@@ -1030,7 +1031,8 @@ class MemoryAwarePrefixCache:
             return False
 
         index = {
-            "version": 2,
+            "version": _CACHE_PERSIST_VERSION,
+            "model_fingerprint": self._model_fingerprint,
             "num_entries": len(self._entries),
             "total_memory_bytes": self._current_memory,
             "entries": [],
@@ -1108,8 +1110,20 @@ class MemoryAwarePrefixCache:
             index = json.load(f)
 
         version = index.get("version", 1)
-        if version < 2:
-            logger.warning(f"[cache_persist] unsupported version {version}, skipping")
+        if version != _CACHE_PERSIST_VERSION:
+            logger.warning(
+                f"[cache_persist] version mismatch: disk={version} "
+                f"current={_CACHE_PERSIST_VERSION}, discarding stale cache"
+            )
+            return 0
+
+        disk_fp = index.get("model_fingerprint", "")
+        if disk_fp and disk_fp != self._model_fingerprint:
+            logger.warning(
+                f"[cache_persist] model fingerprint mismatch: "
+                f"disk={disk_fp} current={self._model_fingerprint}, "
+                f"discarding incompatible cache"
+            )
             return 0
 
         loaded = 0

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -39,6 +39,9 @@ _BYTES_PER_MB = 1024 * 1024
 _DEFAULT_MEMORY_PERCENT = 0.20  # 20% of available RAM
 _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
 _MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
+# Bump this when the cache on-disk format or KV semantics change.
+# Loading a cache with a different version is rejected automatically.
+_CACHE_PERSIST_VERSION = 3
 
 
 def _get_available_memory() -> int:
@@ -420,6 +423,46 @@ def _dequantize_cache(cache: list[Any]) -> list[Any]:
         else:
             result.append(layer)
     return result
+
+
+def _compute_model_fingerprint(model: Any) -> str:
+    """Compute a fingerprint from model architecture for cache compatibility.
+
+    Used to reject disk-persisted caches created by a different model or a
+    different quantisation of the same model. The fingerprint is a short
+    hex digest of (num_hidden_layers, hidden_size, vocab_size,
+    num_key_value_heads, head_dim, intermediate_size, model_type) —
+    lightweight and deterministic.
+
+    Ported from waybarrios/vllm-mlx#365, commit 01261c1.
+    """
+    import hashlib
+
+    cfg = None
+    for cfg_attr in ("config", "args", "model_config"):
+        cfg = getattr(model, cfg_attr, None)
+        if cfg is not None:
+            break
+    if cfg is None:
+        cfg = model
+
+    parts: list[str] = []
+    for key in (
+        "num_hidden_layers",
+        "hidden_size",
+        "vocab_size",
+        "num_key_value_heads",
+        "head_dim",
+        "intermediate_size",
+        "model_type",
+    ):
+        val = getattr(cfg, key, None)
+        if val is not None:
+            parts.append(f"{key}={val}")
+
+    fingerprint = hashlib.sha256("|".join(parts).encode()).hexdigest()[:16]
+    logger.debug(f"[model_fingerprint] {fingerprint} ({', '.join(parts)})")
+    return fingerprint
 
 
 class MemoryAwarePrefixCache:


### PR DESCRIPTION
Closes #29.

## Summary

Ports two targeted upstream fixes from waybarrios/vllm-mlx that together resolve the `--continuous-batching` garbage-on-request-2+ symptom reported in #29:

- **[waybarrios/vllm-mlx#385](https://github.com/waybarrios/vllm-mlx/pull/385)** (`9630c5d`) — `_trim_cache_offset` and `_dequantize_cache` now slice the underlying `keys`/`values` arrays down to `new_offset` instead of just shrinking the `.offset` pointer. Attention paths that read `cache.state` directly (Gemma 4 KV-shared layers upstream, Qwen3 kickoff on supersequence matches in our fork) no longer see stale tokens past the new boundary.
- **[waybarrios/vllm-mlx#365](https://github.com/waybarrios/vllm-mlx/pull/365)** (`01261c1`) — disk-persisted caches carry `_CACHE_PERSIST_VERSION=3` and a 16-char SHA of `(num_hidden_layers, hidden_size, vocab_size, num_key_value_heads, head_dim, intermediate_size, model_type)`. `load_from_disk` discards any entry whose version or fingerprint differs from the current run, so pre-fix caches cannot contaminate a fresh session.

## Root cause (from live reproduction)

Session A seeds cache; Session B loads it; Session B's request-2 matches a stored entry via the supersequence path in `MemoryAwarePrefixCache.fetch`; `_trim_cache_offset` returns a wrapper with `offset=14` but the underlying `keys`/`values` arrays still have `shape[-2]=94` with positions 14..93 holding stale KV from the prior session. Attention reads `cache.state` via the shape, NOT via `offset`, so those stale positions become visible — producing degenerate tokens (`ongo`, `diễn`, etc.).

Verified end-to-end with a real Qwen3-0.6B server: three prompts → restart → cache-hit round → **coherent output on all three** (pre-fix: garbage on 2+). Server log confirms `cache_fetch HIT cached=N remaining=0` + coherent response.

## What changed

- `vllm_mlx/memory_cache.py` — slice arrays in trim + dequantize; add `_CACHE_PERSIST_VERSION=3` + `_compute_model_fingerprint`; gate `load_from_disk` on both.
- `tests/test_memory_cache_mlx.py` (NEW, Apple-Silicon-only) — 7 tests covering plain KVCache slice, QuantizedKVCache passthrough invariants, RotatingKVCache slice (pre-existing type-strip locked down), `_dequantize_cache` slice, end-to-end fetch.
- `tests/test_memory_cache.py` — 3 new Linux-safe tests for fingerprint helper + load gate.
- `tests/test_issue_29_end_to_end.py` (NEW) — 2 user-visible lockdown tests mirroring the issue body.
- `UPSTREAM_PIN.md` — invariants 15 + 16 added, 2026-04-21 entry.
- `CHANGELOG.md` — Unreleased entry.

## What did NOT change

- `scheduler.py`, `prefix_cache.py`, `mllm_*.py`, `engine/batched.py`, `engine/simple.py`, Gemma 4 / Qwen3 parsers — none. All guard test suites pass unchanged:
  - Qwen3 runaway mitigations (PRs #26/#27): **152 pass, 19 integration-deselected**
  - Gemma 4 + MLLM + SimpleEngine: **317 pass, 9 integration-deselected**
  - Full fast suite: **1402 pass** (+6 new; zero new failures; 20 pre-existing concurrency-test failures match `main`)

## Explicit deferrals (follow-up PR, not required for #29)

- `09cc64e` + `b61f57c` (waybarrios#296) — full RotatingKVCache handling. Our KVCache-branch slice fix already covers Rotating models for #29, but the wrapper is type-stripped to plain KVCache (pre-existing quirk). A regression test locks this in so a future Rotating-preserving refactor updates the assertion.
- `d38b978` (waybarrios#286) — 3D KV tensors in `prefix_cache.py` (paged/block-aware tier, not active on the text path that #29 exercises).
- `5d93852` (waybarrios#217) — hybrid recurrent state across blocks.

## Test plan

- [x] `pytest tests/test_memory_cache_mlx.py tests/test_memory_cache.py tests/test_issue_29_end_to_end.py -v` — 63 pass
- [x] Qwen3 runaway + chat-template-kwargs suites — 152 pass
- [x] Gemma 4 + MLLM + SimpleEngine suites — 317 pass
- [x] Broader fast suite — 1402 pass, 0 new failures vs `origin/main`
- [x] Live smoke: `vllm-mlx serve Qwen/Qwen3-0.6B-MLX-4bit --continuous-batching` → seed → restart → cache-hit round → coherent output on all three prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)