### PR TITLE
fix(anthropic): emit signature_delta on streaming thinking blocks (Qwen3 Claude Code silent text drop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Format: entries cite the PR number + a one-line summary. See the PR body for the
   `content_block_delta_count=2, completion=2 tokens` per request.
   Gemma-4-26b-a4b-it-4bit non-regression passed on 0.31.3.
 
-### Anthropic streaming thinking-signature fix (PR #TBD + #TBD-fixes)
+### Anthropic streaming thinking-signature fix (PR #34)
 
 - **Fix Claude Code silently dropping text after thinking blocks on Qwen3.5/3.6 streaming.** Bug doc: [`docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md`](docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md). Non-streaming path was already correct (PR #14); this PR extends the fix to streaming — every thinking content block now carries a `signature_delta` event before `content_block_stop`, both on mid-stream transitions and at final-close.
 - Both paths share `vllm_mlx.api.anthropic_adapter.compute_thinking_signature()` with a byte-parity guard test (`tests/test_anthropic_streaming_thinking_signature.py::test_streaming_signature_matches_non_streaming_byte_for_byte`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ Format: entries cite the PR number + a one-line summary. See the PR body for the
   `content_block_delta_count=2, completion=2 tokens` per request.
   Gemma-4-26b-a4b-it-4bit non-regression passed on 0.31.3.
 
+### Anthropic streaming thinking-signature fix (PR #TBD + #TBD-fixes)
+
+- **Fix Claude Code silently dropping text after thinking blocks on Qwen3.5/3.6 streaming.** Bug doc: [`docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md`](docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md). Non-streaming path was already correct (PR #14); this PR extends the fix to streaming — every thinking content block now carries a `signature_delta` event before `content_block_stop`, both on mid-stream transitions and at final-close.
+- Both paths share `vllm_mlx.api.anthropic_adapter.compute_thinking_signature()` with a byte-parity guard test (`tests/test_anthropic_streaming_thinking_signature.py::test_streaming_signature_matches_non_streaming_byte_for_byte`).
+- Shared close-event emitter `vllm_mlx.server._emit_block_close` dispatches on block type; unknown types raise `ValueError` so a future signable block type cannot silently drop the contract.
+- Adds `thinking_signature_emitted_total` counter (local `_Counter` pattern; `/metrics` endpoint wiring is a follow-up per metrics.py docstring).
+- `[streaming-signature]` INFO log lines include `msg_id` for on-call correlation (both mid-stream and final-close empty-buffer paths).
+- UPSTREAM_PIN.md **invariant 13 extended** to cover streaming + byte-parity. Rebase-sentinel tests in `tests/test_streaming_signature_rebase_sentinel.py` fire loudly if a future rebase drops the dispatcher or its invocation.
+- **Explicitly rejected: `--anthropic-emit-thinking-signatures` feature flag.** Speculative risk to hypothetical non-Claude-Code downstream SDKs pinned to pre-extended-thinking spec versions. `signature_delta` only emits when the model produces thinking content, which only happens when the client opts into extended thinking (via `thinking.type: "adaptive"` or a chat-template `enable_thinking=True`). Non-opt-in clients never see thinking blocks and therefore never see `signature_delta`. Rollback via `git revert` is the accepted safety net.
+
 ### KV cache LCP contamination fix (issue #29)
 
 - **Fix `--continuous-batching` producing garbage on request 2+** ([#29](https://github.com/jackneil/vllm-mlx-patched/issues/29)) — sessions that loaded a persisted prefix cache could return degenerate repetitive output (`ongo`, `diễn`, ...) for the second and later requests. Root cause was twofold:

--- a/UPSTREAM_PIN.md
+++ b/UPSTREAM_PIN.md
@@ -157,13 +157,24 @@ Downstream consumer assumption: `hank-llm-arena::proxy.py::_FORWARDED_HEADERS` f
 
 Test guard: `tests/test_thinking_budget_headers.py` + matrix rows in `tests/test_thinking_budget_matrix.py` + end-to-end integration in `tests/test_qwen3_first_turn_no_think_integration.py` / `tests/test_thinking_budget_ceiling_integration.py`.
 
-### Invariant 13: Non-streaming Anthropic thinking-block ordering and schema
+### Invariant 13: Anthropic thinking-block signature contract (non-streaming AND streaming)
 
-`vllm_mlx.api.anthropic_adapter.openai_to_anthropic` MUST emit a `type: "thinking"` content block BEFORE the `type: "text"` content block when `choice.message.reasoning` is populated. The ordering matches Anthropic's public API and the streaming path (`server.py:1991-2032`).
+`vllm_mlx.api.anthropic_adapter.openai_to_anthropic` MUST emit a `type: "thinking"` content block BEFORE the `type: "text"` content block when `choice.message.reasoning` is populated. The ordering matches Anthropic's public API and the streaming path (`vllm_mlx.server._emit_content_pieces` + `vllm_mlx.server._stream_anthropic_messages` — cite by symbol, not line number, since line numbers drift on rebase).
 
-Every `type: "thinking"` block MUST also be schema-conformant with the Anthropic SDK's `ThinkingBlock` model: it MUST include a `signature: str` field. We populate it with `"vllm-mlx:" + sha256(thinking_text).hexdigest()[:32]` — an opaque, deterministic hash so identical reasoning text produces identical signatures across requests. The prefix distinguishes our signatures from Anthropic's own server-signed values.
+Every `type: "thinking"` block MUST also be schema-conformant with the Anthropic SDK's `ThinkingBlock` model: it MUST include a `signature: str` field. We populate it with `compute_thinking_signature(thinking_text)` (= `"vllm-mlx:" + sha256(thinking_text).hexdigest()[:32]`) — an opaque, deterministic hash so identical reasoning text produces identical signatures across requests. The prefix distinguishes our signatures from Anthropic's own server-signed values.
 
-Test guards: `tests/test_anthropic_adapter_thinking_block.py` (ordering), `tests/test_anthropic_thinking_block_schema.py` (signature contract).
+**Streaming path (added 2026-04-23):** `vllm_mlx.server._stream_anthropic_messages` MUST emit a `signature_delta` event immediately before `content_block_stop` on every content block of `type: "thinking"`, both at mid-stream transitions (inside `_emit_content_pieces`) and at final-close. The emission MUST route through the shared dispatcher `vllm_mlx.server._emit_block_close` which centralizes the close-event sequence and dispatches on block type (raises `ValueError` for unknown types so a new signable block type cannot silently drop the signature contract). Any new signable block type MUST be added to the dispatcher.
+
+Byte-parity: streaming and non-streaming MUST produce identical signatures for identical thinking text. Both paths call `compute_thinking_signature`; no separate formula is permitted.
+
+Test guards (test-id granularity — rename/delete detection):
+- `tests/test_anthropic_adapter_thinking_block.py` — non-streaming ordering
+- `tests/test_anthropic_thinking_block_schema.py` — non-streaming signature contract
+- `tests/test_anthropic_streaming_thinking_signature.py::test_streaming_signature_matches_non_streaming_byte_for_byte` — byte-parity enforcement (formula + input-text drift)
+- `tests/test_anthropic_streaming_thinking_signature.py::test_emitted_events_conform_to_anthropic_streaming_shape` — Anthropic-spec event/delta-type allowlist
+- `tests/test_anthropic_streaming_thinking_signature.py::test_e2e_mid_stream_thinking_to_text_emits_signature` + `test_e2e_final_close_on_open_thinking_emits_signature` — behavioral guards on both production wire-ups
+- `tests/test_streaming_signature_rebase_sentinel.py::test_emit_content_pieces_invokes_emit_block_close` — AST walk; fires if `_emit_content_pieces` stops calling `_emit_block_close`
+- `tests/test_streaming_signature_rebase_sentinel.py::test_stream_anthropic_messages_final_close_invokes_emit_block_close` — source-substring; fires if the final-close in `_stream_anthropic_messages` stops referencing `_emit_block_close`
 
 ### Invariant 14: `chat_template_kwargs` passthrough plumbing (added 2026-04-20)
 

--- a/docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md
+++ b/docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md
@@ -1,0 +1,146 @@
+# Qwen3.x streaming: thinking content blocks emit no `signature`, causing Claude Code to silently drop subsequent text
+
+**Status:** TODO — streaming-path regression on the Anthropic adapter. Non-streaming responses are correct (include `signature` on thinking blocks); streaming responses omit it entirely. Claude Code's client silently discards the text block that follows an unsigned thinking block, making non-tool responses appear empty to the application even though the wire bytes contain the text.
+**Reported:** 2026-04-23, surfaced via `hank-secure-llm`'s `model_qa` harness running against prod `llm.hank.ai` after the concurrent-prefill deadlock (PR #33 / commit 312de2f) closed. Once the deadlock was fixed, the harness stopped timing out and started returning fast empty-result failures on every non-tool scenario.
+**Impact:** High for Claude Code users on Qwen3.5/3.6. Every prompt that returns "thinking → text" produces an empty `.result` in `--output-format=json`. The terminal UI looks like the model failed, even though the inference ran successfully and the upstream stream contains the answer.
+**Scope:** `vllm_mlx/api/anthropic_adapter.py` / `vllm_mlx/server.py` streaming emitter — specifically the path that emits `content_block_start` / `content_block_delta` / `content_block_stop` events for thinking content. The non-streaming path (PR #14, `6b580ba`) already attaches `signature`; the streaming path was never updated to match.
+
+## Symptom (harness)
+
+| scenario (Qwen3.6-35B-A3B-4bit) | result |
+|---|---|
+| `simple_reply` — "Reply with exactly 'OK' and nothing else." | ✗ **empty `.result`**, 3.4s, `stop_reason: end_turn` |
+| `list_output` — "List the numbers 1 to 10..." | ✗ empty, 3.6s |
+| `effort_low` / `effort_high` — "Think step by step: what is 13 × 17?" | ✗ empty, 3-5s |
+| `tool_read` — "Read /tmp/hank-qa/fixture.txt..." | ✅ 6.8s, 2 turns |
+| `tool_write` — "Write 'qa-test-ok' to..." | ✅ 7.0s, 2 turns |
+
+Pattern: any response where the model emits `thinking` followed by `text` produces empty `.result`. Responses where the second block is `tool_use` work fine. Gemma-4-26b passes all seven scenarios because its reasoning parser is a documented no-op (no thinking block emitted).
+
+## Proof: the bug is streaming-path only
+
+Identical payload, two requests, one streaming one not. Same model instance, same PID, seconds apart:
+
+```bash
+# Non-streaming — CORRECT
+$ curl -sS ... -d '{..., "stream": false}' | jq '.content[].type'
+"thinking"
+"text"
+$ curl -sS ... -d '{..., "stream": false}' | jq '.content[0].signature'
+"vllm-mlx:c31d43cb017a637728906835423c96f2"       # ← present
+
+# Streaming — MISSING signature
+$ curl -sS -N ... -d '{..., "stream": true}' | grep -c '"signature"'
+0                                                  # ← never emitted
+```
+
+Full streaming event trace looks like:
+
+```
+event: message_start
+event: content_block_start    {"index":0,"content_block":{"type":"thinking","thinking":""}}
+event: content_block_delta    {"index":0,"delta":{"type":"thinking_delta","thinking":"..."}}
+... (many thinking_deltas) ...
+event: content_block_stop     {"index":0}
+                              ← NO signature_delta here, NO signature on the stop
+event: content_block_start    {"index":1,"content_block":{"type":"text","text":""}}
+event: content_block_delta    {"index":1,"delta":{"type":"text_delta","text":"OK"}}
+event: content_block_stop     {"index":1}
+event: message_delta          {"delta":{"stop_reason":"end_turn"}}
+event: message_stop
+```
+
+The thinking block opens, streams content, then closes without ever carrying a signature. On the non-streaming path, the accumulated response object includes `content[0].signature = "vllm-mlx:<hash>"`. PR #14 (`6b580ba fix(anthropic): required signature field on thinking content blocks`) added this for non-streaming; the streaming emitter was not updated.
+
+## Why Claude Code silently drops the text
+
+Anthropic's `messages` API requires that thinking content blocks carry a `signature` field in both streaming and non-streaming responses (so a client can verify the reasoning wasn't tampered with en route). Claude Code's client-side stream aggregator treats an unsigned thinking block as either (a) an incomplete / malformed response, or (b) a signal that subsequent content blocks in the same message should be discarded (presumably to prevent prompt-injection attacks via unsigned reasoning).
+
+In the failure mode observed:
+
+```json
+{
+  "is_error": false,
+  "result": "",                // ← empty
+  "stop_reason": "end_turn",   // ← clean completion
+  "num_turns": 1,
+  "duration_api_ms": 1877      // ← inference actually succeeded
+}
+```
+
+`is_error` is false and `stop_reason` is `end_turn`, so from the client's perspective nothing failed — but the text that was on the wire never made it into `.result`. Users see a hang-equivalent in their terminal UX even though no timeout occurred.
+
+## Why tool scenarios still pass
+
+When the second block is `tool_use` (not `text`), Claude Code's client parses it as a tool-call intent and dispatches the tool regardless of the thinking block's signature state. The tool response comes back, the model produces a second turn with the tool output included, and the final assistant text block (no preceding thinking) appears in `.result`. This is why the `tool_read` and `tool_write` harness scenarios show 2 turns and populate `.result` correctly, while `simple_reply` / `list_output` / effort-pair (all single-turn, thinking+text shape) show empty.
+
+## Reproduction
+
+No concurrent traffic needed. Single request is sufficient:
+
+```bash
+curl -sS -N -X POST https://llm.hank.ai/v1/messages \
+  -H "Authorization: Bearer $NEURAL_ARENA_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/Qwen3.6-35B-A3B-4bit",
+    "max_tokens": 32000,
+    "stream": true,
+    "output_config": {"effort": "high"},
+    "thinking": {"type": "adaptive"},
+    "messages": [{"role": "user", "content": "Reply with exactly OK"}]
+  }' > /tmp/stream.sse
+
+grep -c '"signature"' /tmp/stream.sse      # → 0 (bug)
+grep -c '"text_delta"' /tmp/stream.sse     # → ≥1 (text IS on the wire)
+```
+
+And the end-to-end through Claude Code:
+
+```bash
+ANTHROPIC_BASE_URL=http://<your-proxy>:<port> \
+ANTHROPIC_API_KEY=<proxy-token> \
+claude --bare -p --output-format json "Reply with exactly 'OK' and nothing else." | jq '.result'
+# → "" (empty, reproduced 5/5 on Qwen3.5 and Qwen3.6 this session)
+```
+
+## Fix direction
+
+The Anthropic streaming spec (as of the 2024 thinking-blocks SDK update) carries signatures via either:
+
+1. A `signature_delta` event in the same pattern as `thinking_delta`, accumulated client-side and finalized on `content_block_stop`, **or**
+2. A `signature` field on the `content_block_stop` event for the thinking block
+
+Option (2) is simpler for the emitter — the server already has the full thinking text at close time, so it can compute the signature then and attach it to the stop event. This matches how the non-streaming path works today (compute signature after the full thinking is accumulated).
+
+Concrete edit location candidates:
+- `vllm_mlx/api/anthropic_adapter.py` — the streaming adapter that converts OpenAI-shaped model output into Anthropic SSE events. The `emit_content_block_stop()` or equivalent function needs to attach the signature when the closing block type is `thinking`.
+- `vllm_mlx/server.py:_stream_anthropic_messages` — the actual SSE writer. If the signature is computed upstream and passed down, this function needs to include it in the event payload.
+
+Reference the non-streaming path's signature computation (from PR #14) — same hash, same prefix (`"vllm-mlx:"`), same input (the concatenated thinking content). Consistency between streaming and non-streaming signatures lets clients reuse validation logic.
+
+**Chosen fix (shipped 2026-04-23):** Option (1) — `signature_delta` delta events before `content_block_stop`. This matches Anthropic's canonical streaming spec and lets clients beyond Claude Code (any Anthropic-SDK-compliant client) reuse their aggregation logic. See plan `docs/superpowers/plans/2026-04-23-qwen3-streaming-thinking-signature.md` and UPSTREAM_PIN.md invariant 13 for details.
+
+## Success criteria
+
+1. Streaming response on Qwen3.5/3.6 emits a non-empty signature on the thinking block — either via `signature_delta` events or as a `signature` field on `content_block_stop` (whichever matches Anthropic's current spec; non-streaming already uses the latter via the response object).
+2. Signature matches what the non-streaming path computes for the same prompt/output (hash prefix `vllm-mlx:`, same bytes as non-stream would produce).
+3. `hank-secure-llm`'s `model_qa` harness running `claude --bare -p` on Qwen3.6 produces non-empty `.result` for the five non-tool scenarios (`simple_reply`, `list_output`, `effort_low`, `effort_high`, `effort_gradient`) — they should flip from ✗ empty to ✓ with content. Tool scenarios should stay ✓.
+4. Regression test: a unit test that fires a streaming thinking+text request at the Anthropic adapter and asserts the `content_block_stop` event for the thinking block contains a signature matching `^vllm-mlx:[0-9a-f]{32}$`. Today this test would fail (signature never emitted); after the fix it must pass.
+5. Cross-family non-regression: Gemma-4 (which doesn't emit thinking) still works — signature emission should only fire on blocks where `type == "thinking"`.
+
+## Related
+
+- PR #14 (`6b580ba`) — fix(anthropic): required signature field on thinking content blocks (**non-streaming only**; this bug is the streaming gap)
+- PR #33 / commit `312de2f` — the concurrent-prefill deadlock fix that unblocked seeing this bug at all (previously these requests just timed out)
+- `docs/testing/2026-04-21-qwen3-35b-a3b-concurrent-heavy-payload-deadlock.md` — the prior deadlock doc; this bug was hidden behind the deadlock until it landed
+- `hank-secure-llm`'s `app/src-tauri/src/proxy.rs` — ruled out as the cause. The proxy is a pure passthrough for thinking/text content blocks (verified by tapping the SSE stream through `dogfood_proxy`: 1 text_delta arrives at Claude Code, matching the direct upstream curl)
+- Arena `hank_llm_arena/proxy.py:proxy_v1` — also ruled out (raw-bytes passthrough after model rewrite + optional system injection)
+
+## Workaround until fix lands
+
+None clean on the client side — Claude Code's signature check is not configurable. Options with trade-offs:
+
+- Strip the `thinking.type` field from outgoing requests so the model doesn't emit thinking blocks at all (loses reasoning quality; user-visible tok/s speedup from skipping thinking might be mistaken for a fix rather than a workaround).
+- Add a proxy-layer streaming transformer that stamps a placeholder `signature` on `content_block_stop` events where `content_block.type == "thinking"`. Works around Claude Code's silent-drop but would cause real signature validation to fail if Claude Code ever adds it — fragile.
+- Ship the real fix upstream. Preferred.

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -556,3 +556,114 @@ def test_interleaved_thinking_via_emit_content_pieces():
     assert len(sig_events) == 2
     assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature("first reasoning")
     assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature("second reasoning")
+
+
+def test_emit_block_close_increments_signature_counter():
+    """/dc M4: the dispatcher must increment thinking_signature_emitted_total
+    exactly once per thinking-block close. Guards against a refactor that
+    drops or double-counts the inc() call — the counter is the only
+    operational signal that the streaming contract is live in prod."""
+    from vllm_mlx.metrics import thinking_signature_emitted_total
+
+    initial = thinking_signature_emitted_total.value
+
+    # Close a thinking block.
+    _emit_block_close("thinking", 0, ["x"])
+    assert thinking_signature_emitted_total.value == initial + 1
+
+    # Close a text block — counter must NOT increment.
+    _emit_block_close("text", 1, [])
+    assert thinking_signature_emitted_total.value == initial + 1
+
+    # Close another thinking block — counter increments again.
+    _emit_block_close("thinking", 2, ["y"])
+    assert thinking_signature_emitted_total.value == initial + 2
+
+
+def test_empty_buffer_close_logs_info_with_msg_id(caplog):
+    """/dc M3 + PM-2: empty thinking buffer at close fires an INFO log
+    that includes msg_id so on-call can correlate unexpected SHA256-of-empty
+    signatures (`vllm-mlx:e3b0c44298fc1c149afbf4c8996fb924`) back to the
+    user-facing request."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="vllm_mlx.server")
+
+    thinking_buffer: list[str] = []
+    events = _emit_block_close(
+        "thinking",
+        7,
+        thinking_buffer,
+        msg_id="msg_deadbeef00000000000000",
+    )
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    info_log = next(
+        (m for m in messages if "[streaming-signature]" in m and "empty buffer" in m),
+        None,
+    )
+    assert info_log is not None, f"empty-buffer INFO log not fired; got: {messages}"
+    assert "msg_id=msg_deadbeef00000000000000" in info_log, info_log
+    assert "idx=7" in info_log, info_log
+
+    parsed = _parse_events(events)
+    assert parsed[0]["data"]["delta"]["signature"] == compute_thinking_signature("")
+
+
+def test_empty_buffer_close_with_none_msg_id_uses_unknown_placeholder(caplog):
+    """/dc PM-2: when msg_id is not provided (unit tests, or a legacy
+    caller), the log line uses `<unknown>` rather than crashing or
+    emitting None."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="vllm_mlx.server")
+
+    thinking_buffer: list[str] = []
+    _emit_block_close("thinking", 0, thinking_buffer)  # no msg_id kwarg
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    info_log = next(
+        (m for m in messages if "[streaming-signature]" in m and "empty buffer" in m),
+        None,
+    )
+    assert info_log is not None
+    assert "msg_id=<unknown>" in info_log, info_log
+
+
+def test_compute_thinking_signature_bounded_latency_realistic_input():
+    """/dc PM-1: guards against pathological latency in compute_thinking_signature
+    on realistic-max inputs. In prod, `--max-thinking-token-budget` (Invariant 12)
+    caps thinking-token budgets; a typical max (32k tokens × ~5 chars/tok) is
+    ≈160 KB of text — sha256 on that should complete in single-digit ms on
+    an M1/M2-class box.
+
+    If this test fails, either:
+    (a) max-thinking-token-budget ceiling is being bypassed in prod, OR
+    (b) compute_thinking_signature has taken on unexpected work beyond the
+        sha256 hash (e.g., a normalize/canonicalize step was added).
+    Either way: investigate before shipping.
+
+    Flakiness guard: 5 samples, assert MEDIAN — robust to single-shot GC
+    pauses or scheduler hiccups on contended CI runners. Threshold is 500ms
+    (100x expected) so a real order-of-magnitude regression still trips it
+    while transient spikes don't.
+    """
+    import statistics
+    import time
+
+    text = "x" * 200_000  # ~200 KB — above the realistic 160 KB cap.
+
+    samples_ms = []
+    for _ in range(5):
+        start = time.perf_counter()
+        sig = compute_thinking_signature(text)
+        samples_ms.append((time.perf_counter() - start) * 1000)
+        assert SIG_RE.match(sig), f"bad signature format: {sig!r}"
+
+    median_ms = statistics.median(samples_ms)
+    assert median_ms < 500, (
+        f"compute_thinking_signature on 200 KB median latency {median_ms:.1f}ms "
+        f"(samples {[f'{s:.1f}' for s in samples_ms]}ms) — expected <500ms. "
+        f"Either the ceiling was removed (PM-1 vulnerability) or the helper "
+        f"picked up extra work beyond sha256. Investigate."
+    )

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -14,6 +14,7 @@ from vllm_mlx.api.anthropic_adapter import (
     compute_thinking_signature,
     openai_to_anthropic,
 )
+from vllm_mlx.server import _emit_block_close, _emit_content_pieces
 
 
 SIG_RE = re.compile(r"^vllm-mlx:[0-9a-f]{32}$")
@@ -38,9 +39,6 @@ def test_helper_signature_format_and_determinism():
         compute_thinking_signature("")
         == "vllm-mlx:" + hashlib.sha256(b"").hexdigest()[:32]
     )
-
-
-from vllm_mlx.server import _emit_block_close
 
 
 def _parse_events(events: list[str]) -> list[dict]:
@@ -125,3 +123,128 @@ def test_emit_block_close_raises_on_unknown_block_type():
             block_index=0,
             thinking_buffer=[],
         )
+
+
+def test_thinking_to_text_transition_emits_signature_before_stop():
+    """Mid-stream close: thinking→text transition emits signature_delta
+    then content_block_stop then the new content_block_start, in that
+    exact order, with block_index preserved on the close and advanced
+    on the open."""
+    thinking_buffer: list[str] = []
+    events, new_type, new_idx = _emit_content_pieces(
+        [("thinking", "Hello"), ("thinking", " world"), ("text", "OK")],
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    types = [(p["event"], p["data"].get("delta", {}).get("type")) for p in parsed]
+    assert types == [
+        ("content_block_start", None),
+        ("content_block_delta", "thinking_delta"),
+        ("content_block_delta", "thinking_delta"),
+        ("content_block_delta", "signature_delta"),
+        ("content_block_stop", None),
+        ("content_block_start", None),
+        ("content_block_delta", "text_delta"),
+    ], f"unexpected sequence: {types}"
+
+    sig_event = parsed[3]["data"]
+    assert sig_event["index"] == 0, "signature_delta must use pre-increment index"
+    assert SIG_RE.match(sig_event["delta"]["signature"])
+    assert sig_event["delta"]["signature"] == compute_thinking_signature("Hello world")
+
+    assert new_type == "text"
+    assert new_idx == 1
+    assert thinking_buffer == []
+
+
+def test_text_only_stream_emits_no_signature_delta():
+    """Non-regression: pure text stream never emits signature_delta and
+    never touches the thinking_buffer."""
+    thinking_buffer: list[str] = []
+    events, new_type, new_idx = _emit_content_pieces(
+        [("text", "hello "), ("text", "world")],
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    joined = "".join(events)
+    assert "signature_delta" not in joined
+    assert "signature" not in joined
+    assert thinking_buffer == []
+    assert new_type == "text"
+    assert new_idx == 0
+
+
+def test_interleaved_thinking_each_block_gets_distinct_signature():
+    """Interleaved thinking (thinking, text, thinking, text) emits a
+    distinct signature per thinking block; buffer clears between them."""
+    thinking_buffer: list[str] = []
+    events, _, final_idx = _emit_content_pieces(
+        [
+            ("thinking", "reasoning A"),
+            ("text", "answer 1"),
+            ("thinking", "reasoning B"),
+            ("text", "answer 2"),
+        ],
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    sig_events = [
+        p for p in parsed
+        if p["data"].get("delta", {}).get("type") == "signature_delta"
+    ]
+    assert len(sig_events) == 2, f"expected 2 sig events, got {len(sig_events)}"
+    assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature("reasoning A")
+    assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature("reasoning B")
+    assert sig_events[0]["data"]["delta"]["signature"] != sig_events[1]["data"]["delta"]["signature"]
+    assert thinking_buffer == []
+    assert final_idx == 3
+
+
+def test_thinking_alone_keeps_block_open_then_final_close_signs_it():
+    """Covers BOTH contracts in one Task-3 test so Task 3's commit ships
+    both the implementation (Step 3.5b final-close wire-up) and the test
+    that exercises it — preserving TDD discipline at the commit level.
+
+    (a) pieces ending on an open thinking block are NOT closed by
+        _emit_content_pieces — that's _stream_anthropic_messages'
+        final-close responsibility.
+    (b) when the caller then invokes the shared dispatcher on the open
+        block (mirroring what the final-close in Step 3.5b does),
+        signature_delta + content_block_stop are emitted and the buffer
+        is cleared.
+    """
+    thinking_buffer: list[str] = []
+    events, new_type, new_idx = _emit_content_pieces(
+        [("thinking", "reasoning, no follow-up")],
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    joined = "".join(events)
+
+    # (a) Not closed by _emit_content_pieces.
+    assert "content_block_stop" not in joined, (
+        "_emit_content_pieces must not close the last block; final-close "
+        "path in _stream_anthropic_messages owns that."
+    )
+    assert thinking_buffer == ["reasoning, no follow-up"]
+    assert new_type == "thinking"
+    assert new_idx == 0
+
+    # (b) The Step 3.5b final-close call pattern.
+    close_events = _emit_block_close(new_type, new_idx, thinking_buffer)
+    close_parsed = _parse_events(close_events)
+    assert [(p["event"], p["data"].get("delta", {}).get("type")) for p in close_parsed] == [
+        ("content_block_delta", "signature_delta"),
+        ("content_block_stop", None),
+    ]
+    assert (
+        close_parsed[0]["data"]["delta"]["signature"]
+        == compute_thinking_signature("reasoning, no follow-up")
+    )
+    assert thinking_buffer == []

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -24,7 +24,6 @@ from vllm_mlx.api.models import (
 )
 from vllm_mlx.server import _emit_block_close, _emit_content_pieces
 
-
 SIG_RE = re.compile(r"^vllm-mlx:[0-9a-f]{32}$")
 
 
@@ -35,7 +34,7 @@ def test_helper_signature_format_and_determinism():
     assert SIG_RE.match(sig), f"bad format: {sig!r}"
     expected = (
         "vllm-mlx:"
-        + hashlib.sha256("Hello world".encode("utf-8")).hexdigest()[:32]
+        + hashlib.sha256(b"Hello world").hexdigest()[:32]
     )
     assert sig == expected
     assert compute_thinking_signature("Hello world") == sig
@@ -469,7 +468,7 @@ def test_emitted_events_conform_to_anthropic_streaming_shape():
     Reference: Anthropic Messages streaming docs §'Extended thinking'.
     If Anthropic moves signature onto content_block_start or introduces
     a new event type, this test fails."""
-    ALLOWED_EVENT_TYPES = {
+    ALLOWED_EVENT_TYPES = {  # noqa: N806 — function-local constant, uppercase for semantic clarity
         "message_start",
         "content_block_start",
         "content_block_delta",
@@ -482,7 +481,7 @@ def test_emitted_events_conform_to_anthropic_streaming_shape():
                   # allowlist should accept them so this test doesn't
                   # flag a future error-event addition.
     }
-    ALLOWED_DELTA_TYPES = {
+    ALLOWED_DELTA_TYPES = {  # noqa: N806 — function-local constant, uppercase for semantic clarity
         "text_delta",
         "thinking_delta",
         "signature_delta",

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -1,0 +1,40 @@
+"""Streaming Anthropic thinking-signature tests.
+
+Covers the shared `compute_thinking_signature()` helper, the
+`_emit_block_close()` dispatcher, and all wired-in emitter behaviors.
+"""
+
+import hashlib
+import json
+import re
+
+import pytest
+
+from vllm_mlx.api.anthropic_adapter import (
+    compute_thinking_signature,
+    openai_to_anthropic,
+)
+
+
+SIG_RE = re.compile(r"^vllm-mlx:[0-9a-f]{32}$")
+
+
+def test_helper_signature_format_and_determinism():
+    """Helper returns a stable `vllm-mlx:<32hex>` for any input; bytes
+    match PR #14's formula (sha256 then first 32 hex chars)."""
+    sig = compute_thinking_signature("Hello world")
+    assert SIG_RE.match(sig), f"bad format: {sig!r}"
+    expected = (
+        "vllm-mlx:"
+        + hashlib.sha256("Hello world".encode("utf-8")).hexdigest()[:32]
+    )
+    assert sig == expected
+    assert compute_thinking_signature("Hello world") == sig
+    assert compute_thinking_signature("Hello World") != sig
+
+    # Empty-string signature is the SHA-256-of-empty constant — a known,
+    # deterministic value. Callers that emit this must do so intentionally.
+    assert (
+        compute_thinking_signature("")
+        == "vllm-mlx:" + hashlib.sha256(b"").hexdigest()[:32]
+    )

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -14,6 +14,14 @@ from vllm_mlx.api.anthropic_adapter import (
     compute_thinking_signature,
     openai_to_anthropic,
 )
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    Usage,
+)
 from vllm_mlx.server import _emit_block_close, _emit_content_pieces
 
 
@@ -248,3 +256,197 @@ def test_thinking_alone_keeps_block_open_then_final_close_signs_it():
         == compute_thinking_signature("reasoning, no follow-up")
     )
     assert thinking_buffer == []
+
+
+# =============================================================================
+# Task 4: Parity + end-to-end coroutine + edge-case tests
+# =============================================================================
+
+
+def _non_streaming_signature_for(thinking_text: str) -> str:
+    response = ChatCompletionResponse(
+        id="test-id",
+        object="chat.completion",
+        created=0,
+        model="any-model",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=AssistantMessage(
+                    role="assistant",
+                    content="final",
+                    reasoning=thinking_text,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    a = openai_to_anthropic(response, model="any-model")
+    thinking_blocks = [b for b in a.content if b.type == "thinking"]
+    assert len(thinking_blocks) == 1 and thinking_blocks[0].signature
+    return thinking_blocks[0].signature
+
+
+def test_streaming_signature_matches_non_streaming_byte_for_byte():
+    """Parity: same thinking text → same signature on both paths, AND
+    the buffered text the streaming path signs == the reasoning text the
+    non-streaming path signs (byte-for-byte, no whitespace normalization)."""
+    text = "Let me think step by step: 13 * 17 = 221."
+    pieces = [
+        ("thinking", "Let me think "),
+        ("thinking", "step by step: "),
+        ("thinking", "13 * 17 = 221."),
+        ("text", "221"),
+    ]
+
+    thinking_buffer: list[str] = []
+    events, _, _ = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    sig_events = [
+        p for p in parsed if p["data"].get("delta", {}).get("type") == "signature_delta"
+    ]
+    assert len(sig_events) == 1
+    streaming_sig = sig_events[0]["data"]["delta"]["signature"]
+    non_streaming_sig = _non_streaming_signature_for(text)
+
+    # Signature bytes match on both paths.
+    assert streaming_sig == non_streaming_sig
+
+    # Independently verify the streaming side signed exactly `text` —
+    # not some joined-with-separator variant.
+    assert streaming_sig == compute_thinking_signature(text)
+    # And the piece-concatenation equals `text` byte-for-byte.
+    assert "".join(t for (bt, t) in pieces if bt == "thinking") == text
+
+
+def test_final_close_on_open_thinking_via_dispatcher():
+    """The final-close path calls _emit_block_close on an open thinking
+    block — same contract as the mid-stream close."""
+    thinking_buffer = ["only thinking, no text follows"]
+    events = _emit_block_close(
+        block_type="thinking",
+        block_index=3,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    assert [(p["event"], p["data"].get("delta", {}).get("type")) for p in parsed] == [
+        ("content_block_delta", "signature_delta"),
+        ("content_block_stop", None),
+    ]
+    assert (
+        parsed[0]["data"]["delta"]["signature"]
+        == compute_thinking_signature("only thinking, no text follows")
+    )
+    assert thinking_buffer == []
+
+
+def test_thinking_to_tool_use_transition_closes_with_signature():
+    """Thinking followed by tool_use (no intervening text) — the thinking
+    block still gets its signature_delta before content_block_stop. The
+    tool_use block itself is opened separately by _stream_anthropic_messages'
+    tool emission loop, which is unchanged; this test pins only the
+    thinking-close half."""
+    thinking_buffer: list[str] = []
+    events, new_type, new_idx = _emit_content_pieces(
+        [("thinking", "I should call the tool")],
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    assert new_type == "thinking"
+    assert "signature_delta" not in "".join(events)
+
+    close_events = _emit_block_close(
+        block_type="thinking",
+        block_index=new_idx,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(close_events)
+    assert parsed[0]["data"]["delta"]["type"] == "signature_delta"
+    assert (
+        parsed[0]["data"]["delta"]["signature"]
+        == compute_thinking_signature("I should call the tool")
+    )
+
+
+# -----------------------------------------------------------------------------
+# End-to-end _stream_anthropic_messages coroutine tests
+# -----------------------------------------------------------------------------
+
+
+class _FakeOutput:
+    """Minimal GenerationOutput shim — _stream_anthropic_messages reads
+    only .new_text, .prompt_tokens, .completion_tokens (with hasattr
+    guards on the latter two)."""
+    def __init__(self, new_text: str):
+        self.new_text = new_text
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+
+
+class _FakeEngine:
+    """Minimal engine shim matching the three attributes
+    _stream_anthropic_messages actually reads. Accepts the chunk list
+    at construction; stream_chat yields them in order."""
+    preserve_native_tool_format = False
+    tokenizer = None  # hasattr-guarded downstream
+
+    def __init__(self, chunks: list[str]):
+        self._chunks = chunks
+
+    async def stream_chat(self, *, messages, **kwargs):
+        for c in self._chunks:
+            yield _FakeOutput(c)
+
+
+async def _drive_stream(engine) -> str:
+    """Helper: run _stream_anthropic_messages against `engine` with a
+    trivial prompt and return the concatenated SSE wire bytes."""
+    from vllm_mlx.server import _stream_anthropic_messages
+
+    req_openai = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "x"}],
+        stream=True,
+    )
+    req_anthropic = AnthropicRequest(
+        model="test-model",
+        max_tokens=1000,
+        messages=[{"role": "user", "content": "x"}],
+        stream=True,
+    )
+
+    pieces = []
+    async for ev in _stream_anthropic_messages(engine, req_openai, req_anthropic):
+        pieces.append(ev)
+    return "".join(pieces)
+
+
+@pytest.mark.asyncio
+async def test_e2e_mid_stream_thinking_to_text_emits_signature():
+    """End-to-end (a): thinking→text transition."""
+    engine = _FakeEngine(["<think>", "hello ", "world", "</think>", "answer"])
+    wire = await _drive_stream(engine)
+    assert wire.count('"signature_delta"') == 1, (
+        f"expected 1 signature_delta on mid-stream close, wire:\n{wire}"
+    )
+    expected_sig = compute_thinking_signature("hello world")
+    assert expected_sig in wire, f"expected signature {expected_sig!r} not on wire"
+
+
+@pytest.mark.asyncio
+async def test_e2e_final_close_on_open_thinking_emits_signature():
+    """End-to-end (b): stream terminates with an open thinking block."""
+    engine = _FakeEngine(["<think>", "hello ", "world"])  # no </think>, no text
+    wire = await _drive_stream(engine)
+    assert wire.count('"signature_delta"') == 1, (
+        f"expected 1 signature_delta from final-close, wire:\n{wire}"
+    )
+    expected_sig = compute_thinking_signature("hello world")
+    assert expected_sig in wire, f"expected signature {expected_sig!r} not on wire"

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -38,3 +38,90 @@ def test_helper_signature_format_and_determinism():
         compute_thinking_signature("")
         == "vllm-mlx:" + hashlib.sha256(b"").hexdigest()[:32]
     )
+
+
+from vllm_mlx.server import _emit_block_close
+
+
+def _parse_events(events: list[str]) -> list[dict]:
+    """Parse SSE event strings into {event, data} dicts for assertion."""
+    out = []
+    for raw in events:
+        lines = raw.strip().split("\n")
+        assert lines[0].startswith("event: "), raw
+        assert lines[1].startswith("data: "), raw
+        out.append(
+            {
+                "event": lines[0][len("event: "):],
+                "data": json.loads(lines[1][len("data: "):]),
+            }
+        )
+    return out
+
+
+def test_emit_block_close_thinking_emits_signature_then_stop():
+    """Dispatcher's thinking branch: signature_delta then content_block_stop
+    on the same index, buffer cleared in place."""
+    thinking_buffer = ["Hello", " world"]
+    events = _emit_block_close(
+        block_type="thinking",
+        block_index=7,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    assert len(parsed) == 2
+    assert parsed[0]["data"] == {
+        "type": "content_block_delta",
+        "index": 7,
+        "delta": {
+            "type": "signature_delta",
+            "signature": compute_thinking_signature("Hello world"),
+        },
+    }
+    assert SIG_RE.match(parsed[0]["data"]["delta"]["signature"])
+    assert parsed[1]["data"] == {"type": "content_block_stop", "index": 7}
+    assert thinking_buffer == []
+
+
+def test_emit_block_close_text_emits_bare_stop_and_does_not_touch_buffer():
+    """Dispatcher's text branch: bare content_block_stop; thinking_buffer
+    is not touched (even if non-empty from a prior block's leftovers —
+    normal callers clear it before reaching here)."""
+    thinking_buffer = ["leftover — caller should have cleared"]
+    events = _emit_block_close(
+        block_type="text",
+        block_index=3,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    assert len(parsed) == 1
+    assert parsed[0]["data"] == {"type": "content_block_stop", "index": 3}
+    assert thinking_buffer == ["leftover — caller should have cleared"]
+
+
+def test_emit_block_close_empty_thinking_buffer_emits_known_empty_sig():
+    """Defensive: an empty thinking buffer still emits a signature (the
+    SHA-256-of-empty constant). This matches Anthropic's spec that signature
+    is REQUIRED on thinking blocks, not conditional on non-empty content.
+    Logs a one-line diagnostic but is not an error."""
+    thinking_buffer: list[str] = []
+    events = _emit_block_close(
+        block_type="thinking",
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+    assert parsed[0]["data"]["delta"]["type"] == "signature_delta"
+    assert parsed[0]["data"]["delta"]["signature"] == compute_thinking_signature("")
+
+
+def test_emit_block_close_raises_on_unknown_block_type():
+    """Regression guard: a new block type added to _emit_content_pieces
+    that forgets to teach _emit_block_close about itself gets a loud
+    ValueError instead of a silent content-drop."""
+    with pytest.raises(ValueError, match="unhandled block_type"):
+        _emit_block_close(
+            block_type="redacted_thinking",
+            block_index=0,
+            thinking_buffer=[],
+        )

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -32,10 +32,7 @@ def test_helper_signature_format_and_determinism():
     match PR #14's formula (sha256 then first 32 hex chars)."""
     sig = compute_thinking_signature("Hello world")
     assert SIG_RE.match(sig), f"bad format: {sig!r}"
-    expected = (
-        "vllm-mlx:"
-        + hashlib.sha256(b"Hello world").hexdigest()[:32]
-    )
+    expected = "vllm-mlx:" + hashlib.sha256(b"Hello world").hexdigest()[:32]
     assert sig == expected
     assert compute_thinking_signature("Hello world") == sig
     assert compute_thinking_signature("Hello World") != sig
@@ -57,8 +54,8 @@ def _parse_events(events: list[str]) -> list[dict]:
         assert lines[1].startswith("data: "), raw
         out.append(
             {
-                "event": lines[0][len("event: "):],
-                "data": json.loads(lines[1][len("data: "):]),
+                "event": lines[0][len("event: ") :],
+                "data": json.loads(lines[1][len("data: ") :]),
             }
         )
     return out
@@ -201,13 +198,19 @@ def test_interleaved_thinking_each_block_gets_distinct_signature():
     )
     parsed = _parse_events(events)
     sig_events = [
-        p for p in parsed
-        if p["data"].get("delta", {}).get("type") == "signature_delta"
+        p for p in parsed if p["data"].get("delta", {}).get("type") == "signature_delta"
     ]
     assert len(sig_events) == 2, f"expected 2 sig events, got {len(sig_events)}"
-    assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature("reasoning A")
-    assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature("reasoning B")
-    assert sig_events[0]["data"]["delta"]["signature"] != sig_events[1]["data"]["delta"]["signature"]
+    assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "reasoning A"
+    )
+    assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "reasoning B"
+    )
+    assert (
+        sig_events[0]["data"]["delta"]["signature"]
+        != sig_events[1]["data"]["delta"]["signature"]
+    )
     assert thinking_buffer == []
     assert final_idx == 3
 
@@ -246,13 +249,14 @@ def test_thinking_alone_keeps_block_open_then_final_close_signs_it():
     # (b) The Step 3.5b final-close call pattern.
     close_events = _emit_block_close(new_type, new_idx, thinking_buffer)
     close_parsed = _parse_events(close_events)
-    assert [(p["event"], p["data"].get("delta", {}).get("type")) for p in close_parsed] == [
+    assert [
+        (p["event"], p["data"].get("delta", {}).get("type")) for p in close_parsed
+    ] == [
         ("content_block_delta", "signature_delta"),
         ("content_block_stop", None),
     ]
-    assert (
-        close_parsed[0]["data"]["delta"]["signature"]
-        == compute_thinking_signature("reasoning, no follow-up")
+    assert close_parsed[0]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "reasoning, no follow-up"
     )
     assert thinking_buffer == []
 
@@ -338,9 +342,8 @@ def test_final_close_on_open_thinking_via_dispatcher():
         ("content_block_delta", "signature_delta"),
         ("content_block_stop", None),
     ]
-    assert (
-        parsed[0]["data"]["delta"]["signature"]
-        == compute_thinking_signature("only thinking, no text follows")
+    assert parsed[0]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "only thinking, no text follows"
     )
     assert thinking_buffer == []
 
@@ -368,9 +371,8 @@ def test_thinking_to_tool_use_transition_closes_with_signature():
     )
     parsed = _parse_events(close_events)
     assert parsed[0]["data"]["delta"]["type"] == "signature_delta"
-    assert (
-        parsed[0]["data"]["delta"]["signature"]
-        == compute_thinking_signature("I should call the tool")
+    assert parsed[0]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "I should call the tool"
     )
 
 
@@ -383,6 +385,7 @@ class _FakeOutput:
     """Minimal GenerationOutput shim — _stream_anthropic_messages reads
     only .new_text, .prompt_tokens, .completion_tokens (with hasattr
     guards on the latter two)."""
+
     def __init__(self, new_text: str):
         self.new_text = new_text
         self.prompt_tokens = 0
@@ -393,6 +396,7 @@ class _FakeEngine:
     """Minimal engine shim matching the three attributes
     _stream_anthropic_messages actually reads. Accepts the chunk list
     at construction; stream_chat yields them in order."""
+
     preserve_native_tool_format = False
     tokenizer = None  # hasattr-guarded downstream
 
@@ -432,9 +436,9 @@ async def test_e2e_mid_stream_thinking_to_text_emits_signature():
     """End-to-end (a): thinking→text transition."""
     engine = _FakeEngine(["<think>", "hello ", "world", "</think>", "answer"])
     wire = await _drive_stream(engine)
-    assert wire.count('"signature_delta"') == 1, (
-        f"expected 1 signature_delta on mid-stream close, wire:\n{wire}"
-    )
+    assert (
+        wire.count('"signature_delta"') == 1
+    ), f"expected 1 signature_delta on mid-stream close, wire:\n{wire}"
     expected_sig = compute_thinking_signature("hello world")
     assert expected_sig in wire, f"expected signature {expected_sig!r} not on wire"
 
@@ -444,9 +448,9 @@ async def test_e2e_final_close_on_open_thinking_emits_signature():
     """End-to-end (b): stream terminates with an open thinking block."""
     engine = _FakeEngine(["<think>", "hello ", "world"])  # no </think>, no text
     wire = await _drive_stream(engine)
-    assert wire.count('"signature_delta"') == 1, (
-        f"expected 1 signature_delta from final-close, wire:\n{wire}"
-    )
+    assert (
+        wire.count('"signature_delta"') == 1
+    ), f"expected 1 signature_delta from final-close, wire:\n{wire}"
     expected_sig = compute_thinking_signature("hello world")
     assert expected_sig in wire, f"expected signature {expected_sig!r} not on wire"
 
@@ -477,16 +481,18 @@ def test_emitted_events_conform_to_anthropic_streaming_shape():
         "message_stop",
         "ping",
         "error",  # Anthropic emits `error` events on server-side failures.
-                  # Our emitter doesn't produce them today but the
-                  # allowlist should accept them so this test doesn't
-                  # flag a future error-event addition.
+        # Our emitter doesn't produce them today but the
+        # allowlist should accept them so this test doesn't
+        # flag a future error-event addition.
     }
-    ALLOWED_DELTA_TYPES = {  # noqa: N806 — function-local constant, uppercase for semantic clarity
-        "text_delta",
-        "thinking_delta",
-        "signature_delta",
-        "input_json_delta",
-    }
+    ALLOWED_DELTA_TYPES = (
+        {  # noqa: N806 — function-local constant, uppercase for semantic clarity
+            "text_delta",
+            "thinking_delta",
+            "signature_delta",
+            "input_json_delta",
+        }
+    )
 
     thinking_buffer: list[str] = []
     events, _, _ = _emit_content_pieces(
@@ -499,16 +505,16 @@ def test_emitted_events_conform_to_anthropic_streaming_shape():
 
     for p in parsed:
         # Event type must be Anthropic-spec-known.
-        assert p["event"] in ALLOWED_EVENT_TYPES, (
-            f"unknown event type {p['event']!r}; not in Anthropic spec"
-        )
+        assert (
+            p["event"] in ALLOWED_EVENT_TYPES
+        ), f"unknown event type {p['event']!r}; not in Anthropic spec"
         # content_block_delta carries a typed delta.
         if p["event"] == "content_block_delta":
             delta = p["data"].get("delta")
             assert isinstance(delta, dict), f"no delta: {p}"
-            assert delta.get("type") in ALLOWED_DELTA_TYPES, (
-                f"unknown delta type {delta.get('type')!r}"
-            )
+            assert (
+                delta.get("type") in ALLOWED_DELTA_TYPES
+            ), f"unknown delta type {delta.get('type')!r}"
             # signature_delta carries a string `signature` field.
             if delta["type"] == "signature_delta":
                 sig = delta.get("signature")
@@ -554,8 +560,12 @@ def test_interleaved_thinking_via_emit_content_pieces():
         p for p in parsed if p["data"].get("delta", {}).get("type") == "signature_delta"
     ]
     assert len(sig_events) == 2
-    assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature("first reasoning")
-    assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature("second reasoning")
+    assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "first reasoning"
+    )
+    assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature(
+        "second reasoning"
+    )
 
 
 def test_emit_block_close_increments_signature_counter():

--- a/tests/test_anthropic_streaming_thinking_signature.py
+++ b/tests/test_anthropic_streaming_thinking_signature.py
@@ -450,3 +450,110 @@ async def test_e2e_final_close_on_open_thinking_emits_signature():
     )
     expected_sig = compute_thinking_signature("hello world")
     assert expected_sig in wire, f"expected signature {expected_sig!r} not on wire"
+
+
+# =============================================================================
+# Task 5: Anthropic-spec conformance + interleaved-thinking integration
+# =============================================================================
+
+
+def test_emitted_events_conform_to_anthropic_streaming_shape():
+    """Anthropic streaming spec (extended thinking): each event is one of
+    {message_start, content_block_start, content_block_delta,
+    content_block_stop, message_delta, message_stop, ping}. Signature
+    arrives via content_block_delta with delta.type == signature_delta
+    and a string delta.signature. This test asserts the shape WITHOUT
+    referencing our own string literals, so it catches drift between our
+    emitter and the spec.
+
+    Reference: Anthropic Messages streaming docs §'Extended thinking'.
+    If Anthropic moves signature onto content_block_start or introduces
+    a new event type, this test fails."""
+    ALLOWED_EVENT_TYPES = {
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+        "ping",
+        "error",  # Anthropic emits `error` events on server-side failures.
+                  # Our emitter doesn't produce them today but the
+                  # allowlist should accept them so this test doesn't
+                  # flag a future error-event addition.
+    }
+    ALLOWED_DELTA_TYPES = {
+        "text_delta",
+        "thinking_delta",
+        "signature_delta",
+        "input_json_delta",
+    }
+
+    thinking_buffer: list[str] = []
+    events, _, _ = _emit_content_pieces(
+        [("thinking", "Hello"), ("text", "OK")],
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+    )
+    parsed = _parse_events(events)
+
+    for p in parsed:
+        # Event type must be Anthropic-spec-known.
+        assert p["event"] in ALLOWED_EVENT_TYPES, (
+            f"unknown event type {p['event']!r}; not in Anthropic spec"
+        )
+        # content_block_delta carries a typed delta.
+        if p["event"] == "content_block_delta":
+            delta = p["data"].get("delta")
+            assert isinstance(delta, dict), f"no delta: {p}"
+            assert delta.get("type") in ALLOWED_DELTA_TYPES, (
+                f"unknown delta type {delta.get('type')!r}"
+            )
+            # signature_delta carries a string `signature` field.
+            if delta["type"] == "signature_delta":
+                sig = delta.get("signature")
+                assert isinstance(sig, str) and len(sig) > 0
+
+
+def test_interleaved_thinking_via_emit_content_pieces():
+    """Interleaved-thinking across multiple _emit_content_pieces calls
+    (simulating deltas arriving in batches over many coroutine ticks).
+    Each thinking block must get its own signature at transition time."""
+    thinking_buffer: list[str] = []
+    state = {"current_block_type": None, "block_index": 0}
+    all_events: list[str] = []
+
+    def drive(pieces):
+        events, bt, bi = _emit_content_pieces(
+            pieces,
+            current_block_type=state["current_block_type"],
+            block_index=state["block_index"],
+            thinking_buffer=thinking_buffer,
+        )
+        state["current_block_type"] = bt
+        state["block_index"] = bi
+        all_events.extend(events)
+
+    drive([("thinking", "first reasoning")])
+    drive([("text", "first answer")])
+    drive([("thinking", "second reasoning")])
+    drive([("text", "second answer")])
+
+    # Close whatever is still open via dispatcher.
+    if state["current_block_type"] is not None:
+        all_events.extend(
+            _emit_block_close(
+                state["current_block_type"],
+                state["block_index"],
+                thinking_buffer,
+            )
+        )
+
+    parsed = _parse_events(all_events)
+    sig_events = [
+        p for p in parsed if p["data"].get("delta", {}).get("type") == "signature_delta"
+    ]
+    assert len(sig_events) == 2
+    assert sig_events[0]["data"]["delta"]["signature"] == compute_thinking_signature("first reasoning")
+    assert sig_events[1]["data"]["delta"]["signature"] == compute_thinking_signature("second reasoning")

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -16,7 +16,9 @@ class TestEmitContentPieces(unittest.TestCase):
     """Test the refactored _emit_content_pieces helper."""
 
     def test_single_text_block(self):
-        events, block_type, index = _emit_content_pieces([("text", "hello")], None, 0)
+        events, block_type, index = _emit_content_pieces(
+            [("text", "hello")], None, 0, []
+        )
         assert len(events) == 2  # block_start + delta
         assert block_type == "text"
         assert index == 0
@@ -30,7 +32,7 @@ class TestEmitContentPieces(unittest.TestCase):
 
     def test_single_thinking_block(self):
         events, block_type, index = _emit_content_pieces(
-            [("thinking", "reasoning")], None, 0
+            [("thinking", "reasoning")], None, 0, []
         )
         assert block_type == "thinking"
         delta_data = json.loads(events[1].split("data: ")[1])
@@ -38,23 +40,28 @@ class TestEmitContentPieces(unittest.TestCase):
 
     def test_transition_thinking_to_text(self):
         events, block_type, index = _emit_content_pieces(
-            [("thinking", "reason"), ("text", "answer")], None, 0
+            [("thinking", "reason"), ("text", "answer")], None, 0, []
         )
         assert block_type == "text"
         assert index == 1  # incremented on block transition
-        # Should have: start_thinking, delta_thinking, stop_thinking, start_text, delta_text
-        assert len(events) == 5
-        stop_data = json.loads(events[2].split("data: ")[1])
+        # Should have: start_thinking, delta_thinking, signature_delta,
+        # stop_thinking, start_text, delta_text
+        assert len(events) == 6
+        sig_data = json.loads(events[2].split("data: ")[1])
+        assert sig_data["delta"]["type"] == "signature_delta"
+        stop_data = json.loads(events[3].split("data: ")[1])
         assert stop_data["type"] == "content_block_stop"
 
     def test_continues_existing_block(self):
         """If current_block_type matches, no start/stop emitted."""
-        events, block_type, index = _emit_content_pieces([("text", "more")], "text", 0)
+        events, block_type, index = _emit_content_pieces(
+            [("text", "more")], "text", 0, []
+        )
         assert len(events) == 1  # just delta, no start
         assert block_type == "text"
 
     def test_empty_pieces(self):
-        events, block_type, index = _emit_content_pieces([], None, 0)
+        events, block_type, index = _emit_content_pieces([], None, 0, [])
         assert events == []
         assert block_type is None
         assert index == 0
@@ -69,6 +76,9 @@ class TestStreamingPipelineIntegration(unittest.TestCase):
         think_router = StreamingThinkRouter(start_in_thinking=start_in_thinking)
         current_block_type = None
         block_index = 0
+        # Caller-owned buffer threaded through every _emit_content_pieces
+        # call in this request, mirroring production semantics.
+        buf: list[str] = []
         all_events = []
         accumulated_text = ""
 
@@ -79,7 +89,7 @@ class TestStreamingPipelineIntegration(unittest.TestCase):
                 continue
             pieces = think_router.process(filtered)
             events, current_block_type, block_index = _emit_content_pieces(
-                pieces, current_block_type, block_index
+                pieces, current_block_type, block_index, buf
             )
             all_events.extend(events)
 
@@ -88,14 +98,14 @@ class TestStreamingPipelineIntegration(unittest.TestCase):
         if remaining:
             pieces = think_router.process(remaining)
             events, current_block_type, block_index = _emit_content_pieces(
-                pieces, current_block_type, block_index
+                pieces, current_block_type, block_index, buf
             )
             all_events.extend(events)
 
         flush_pieces = think_router.flush()
         if flush_pieces:
             events, current_block_type, block_index = _emit_content_pieces(
-                flush_pieces, current_block_type, block_index
+                flush_pieces, current_block_type, block_index, buf
             )
             all_events.extend(events)
 

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -8,7 +8,7 @@ prompt_tokens tracking work together correctly.
 import json
 import unittest
 
-from vllm_mlx.api.utils import StreamingToolCallFilter, StreamingThinkRouter
+from vllm_mlx.api.utils import StreamingThinkRouter, StreamingToolCallFilter
 from vllm_mlx.server import _emit_content_pieces
 
 

--- a/tests/test_streaming_signature_rebase_sentinel.py
+++ b/tests/test_streaming_signature_rebase_sentinel.py
@@ -10,12 +10,12 @@ and tests/test_mlx_lm_api_contract.py.
 import ast
 import inspect
 
+from vllm_mlx.api.anthropic_adapter import compute_thinking_signature
 from vllm_mlx.server import (
     _emit_block_close,
     _emit_content_pieces,
     _stream_anthropic_messages,
 )
-from vllm_mlx.api.anthropic_adapter import compute_thinking_signature
 
 
 def test_compute_thinking_signature_helper_exists():

--- a/tests/test_streaming_signature_rebase_sentinel.py
+++ b/tests/test_streaming_signature_rebase_sentinel.py
@@ -1,0 +1,73 @@
+"""Rebase sentinel for Invariant 13 (streaming signature contract).
+
+If a rebase reverts the signature emission in _emit_content_pieces
+(restoring the pre-fix bare content_block_stop path), this test fires
+with a loud error pointing at UPSTREAM_PIN.md. The pattern mirrors
+tests/test_reasoning_parser_properties.py::TestRebaseBreakageSentinel
+and tests/test_mlx_lm_api_contract.py.
+"""
+
+import ast
+import inspect
+
+from vllm_mlx.server import (
+    _emit_block_close,
+    _emit_content_pieces,
+    _stream_anthropic_messages,
+)
+from vllm_mlx.api.anthropic_adapter import compute_thinking_signature
+
+
+def test_compute_thinking_signature_helper_exists():
+    """Invariant 13: shared helper `compute_thinking_signature` is the
+    single source of truth for the signature formula. Rebase must preserve
+    both its existence and its name (server.py imports by name)."""
+    assert callable(compute_thinking_signature)
+    sig = compute_thinking_signature("")
+    assert sig.startswith("vllm-mlx:") and len(sig) == len("vllm-mlx:") + 32
+
+
+def test_emit_block_close_dispatcher_exists():
+    """Invariant 13: `_emit_block_close` dispatches on block_type with a
+    `thinking` branch that emits signature_delta. Rebase must preserve
+    the dispatcher and its name."""
+    assert callable(_emit_block_close)
+    events = _emit_block_close("thinking", 0, ["x"])
+    assert len(events) == 2
+    assert "signature_delta" in events[0]
+
+
+def test_emit_content_pieces_invokes_emit_block_close():
+    """Invariant 13 rebase guard: _emit_content_pieces MUST call
+    _emit_block_close when transitioning off a thinking block. AST walk
+    of the function source asserts the call-by-name is present. If a
+    rebase restores the old bare-stop pattern, this test fails with a
+    pointer to UPSTREAM_PIN.md."""
+    source = inspect.getsource(_emit_content_pieces)
+    tree = ast.parse(source)
+    call_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            call_names.add(node.func.id)
+    assert "_emit_block_close" in call_names, (
+        "Invariant 13 (streaming) regression: _emit_content_pieces no "
+        "longer calls _emit_block_close. A rebase likely restored the "
+        "pre-fix bare content_block_stop pattern — Anthropic streaming "
+        "thinking blocks will emit no signature, and Claude Code will "
+        "silently drop the text that follows. See UPSTREAM_PIN.md "
+        "invariant 13 and docs/testing/"
+        "2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md."
+    )
+
+
+def test_stream_anthropic_messages_final_close_invokes_emit_block_close():
+    """Invariant 13 rebase guard: the final-close in _stream_anthropic_messages
+    MUST also route through _emit_block_close so a stream that terminates
+    with an open thinking block still emits a signature."""
+    source = inspect.getsource(_stream_anthropic_messages)
+    assert "_emit_block_close" in source, (
+        "Invariant 13 (streaming) regression: _stream_anthropic_messages "
+        "no longer references _emit_block_close in its final-close path. "
+        "A stream ending on an open thinking block will emit no signature. "
+        "See UPSTREAM_PIN.md invariant 13."
+    )

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -269,10 +269,7 @@ def compute_thinking_signature(thinking_text: str) -> str:
     breaks the parity contract enforced by
     test_streaming_signature_matches_non_streaming_byte_for_byte.
     """
-    return (
-        "vllm-mlx:"
-        + hashlib.sha256(thinking_text.encode("utf-8")).hexdigest()[:32]
-    )
+    return "vllm-mlx:" + hashlib.sha256(thinking_text.encode("utf-8")).hexdigest()[:32]
 
 
 def openai_to_anthropic(

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -253,6 +253,28 @@ def anthropic_to_openai(
     return openai_req, resolved
 
 
+def compute_thinking_signature(thinking_text: str) -> str:
+    """Deterministic opaque signature for an Anthropic thinking block.
+
+    Single source of truth for the "vllm-mlx:<32hex>" signature formula
+    shared by the non-streaming `openai_to_anthropic` adapter and the
+    streaming `_emit_block_close` emitter in server.py. The "vllm-mlx:"
+    prefix distinguishes our signatures from Anthropic's own server-signed
+    values. Identical thinking text always yields an identical signature
+    (useful for replay/caching).
+
+    Callers MUST pass the thinking text byte-identical to what non-streaming
+    would see in `choice.message.reasoning` — order and whitespace
+    preserved. Any join/strip/normalize on one side and not the other
+    breaks the parity contract enforced by
+    test_streaming_signature_matches_non_streaming_byte_for_byte.
+    """
+    return (
+        "vllm-mlx:"
+        + hashlib.sha256(thinking_text.encode("utf-8")).hexdigest()[:32]
+    )
+
+
 def openai_to_anthropic(
     response: ChatCompletionResponse,
     model: str,
@@ -275,12 +297,7 @@ def openai_to_anthropic(
         # Matches Anthropic's public API and the streaming path
         # (server.py:1991-2032).
         if choice.message.reasoning:
-            sig = (
-                "vllm-mlx:"
-                + hashlib.sha256(choice.message.reasoning.encode("utf-8")).hexdigest()[
-                    :32
-                ]
-            )
+            sig = compute_thinking_signature(choice.message.reasoning)
             content.append(
                 AnthropicResponseContentBlock(
                     type="thinking",

--- a/vllm_mlx/metrics.py
+++ b/vllm_mlx/metrics.py
@@ -29,6 +29,14 @@ class _Counter:
 # broken tokenizer, etc.). Alert on rate > 0 if budget is expected to work.
 thinking_budget_noop_total = _Counter("thinking_budget_noop_total")
 
+# Increments once per streaming Anthropic thinking-content-block close
+# (one per _emit_block_close call with block_type='thinking'). Operators
+# use this to confirm the streaming-signature contract is live in prod —
+# compare rate against request rate with Anthropic-streaming thinking
+# requests. No per-model dimension (the _Counter class doesn't support
+# labels today); correlate per-model via msg_id + request logs.
+thinking_signature_emitted_total = _Counter("thinking_signature_emitted_total")
+
 # Increments every time a streaming response terminated because the
 # --streaming-max-seconds wall-clock cap fired. Distinct from organic
 # finish_reason="length" (model hit max_tokens naturally) — cap-firings

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2799,7 +2799,9 @@ def _emit_content_pieces(
             if current_block_type is not None:
                 events.extend(
                     _emit_block_close(
-                        current_block_type, block_index, thinking_buffer,
+                        current_block_type,
+                        block_index,
+                        thinking_buffer,
                         msg_id=msg_id,
                     )
                 )
@@ -3073,7 +3075,10 @@ async def _stream_anthropic_messages(
                 # Stage 2: route thinking vs text
                 pieces = think_router.process(filtered)
                 events, current_block_type, block_index = _emit_content_pieces(
-                    pieces, current_block_type, block_index, thinking_buffer,
+                    pieces,
+                    current_block_type,
+                    block_index,
+                    thinking_buffer,
                     msg_id=msg_id,
                 )
                 for event in events:
@@ -3095,7 +3100,10 @@ async def _stream_anthropic_messages(
     flush_pieces = think_router.flush()
     if flush_pieces:
         events, current_block_type, block_index = _emit_content_pieces(
-            flush_pieces, current_block_type, block_index, thinking_buffer,
+            flush_pieces,
+            current_block_type,
+            block_index,
+            thinking_buffer,
             msg_id=msg_id,
         )
         for event in events:
@@ -3108,7 +3116,10 @@ async def _stream_anthropic_messages(
     # clean stop with thinking but no text).
     if current_block_type is not None:
         for ev in _emit_block_close(
-            current_block_type, block_index, thinking_buffer, msg_id=msg_id,
+            current_block_type,
+            block_index,
+            thinking_buffer,
+            msg_id=msg_id,
         ):
             yield ev
         block_index += 1

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2751,31 +2751,39 @@ def _emit_content_pieces(
     pieces: list[tuple[str, str]],
     current_block_type: str | None,
     block_index: int,
+    thinking_buffer: list[str],
 ) -> tuple[list[str], str | None, int]:
     """Emit Anthropic SSE events for content pieces from the think router.
 
     Handles block type transitions (thinking <-> text), emitting
-    content_block_start/stop/delta events as needed.
+    content_block_start/stop/delta events as needed. When closing a
+    `thinking` block, uses _emit_block_close() to emit signature_delta +
+    content_block_stop so streaming matches the non-streaming signature
+    contract (UPSTREAM_PIN.md invariant 13).
 
     Args:
         pieces: List of (block_type, text) from StreamingThinkRouter
-        current_block_type: Current open block type, or None
+        current_block_type: Currently-open block type, or None
         block_index: Current block index
+        thinking_buffer: Caller-owned accumulator for thinking-block text.
+            Mutated in place — appended while a thinking block is open,
+            cleared by _emit_block_close() when the block closes. The
+            caller MUST allocate a fresh list at the top of each request's
+            streaming coroutine. Sharing a buffer across requests is a bug.
 
     Returns:
-        Tuple of (events, updated_block_type, updated_block_index)
+        (events, updated_block_type, updated_block_index). The final open
+        block (if any) is NOT closed here; _stream_anthropic_messages'
+        final-close owns that.
     """
     events = []
     for block_type, text in pieces:
         if block_type != current_block_type:
-            # Close previous block if open
             if current_block_type is not None:
-                events.append(
-                    f"event: content_block_stop\ndata: "
-                    f"{json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+                events.extend(
+                    _emit_block_close(current_block_type, block_index, thinking_buffer)
                 )
                 block_index += 1
-            # Start new block
             current_block_type = block_type
             content_block = (
                 {"type": block_type, "text": ""}
@@ -2786,7 +2794,8 @@ def _emit_content_pieces(
                 f"event: content_block_start\ndata: "
                 f"{json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': content_block})}\n\n"
             )
-        # Emit delta
+        if block_type == "thinking":
+            thinking_buffer.append(text)
         delta_key = "thinking" if block_type == "thinking" else "text"
         delta_type = "thinking_delta" if block_type == "thinking" else "text_delta"
         delta_event = {
@@ -2926,6 +2935,10 @@ async def _stream_anthropic_messages(
     # Track which content blocks we've started
     current_block_type = None  # "thinking" or "text"
     block_index = 0
+    # Caller-owned accumulator for thinking-block text. Threaded through
+    # _emit_content_pieces; cleared by _emit_block_close() when a thinking
+    # block closes. Fresh per request — sharing across requests is a bug.
+    thinking_buffer: list[str] = []
 
     # Server-side streaming cap — guards against Qwen3.x "interleaved
     # thinking" trap and any other model-side non-termination. When the
@@ -3040,7 +3053,7 @@ async def _stream_anthropic_messages(
                 # Stage 2: route thinking vs text
                 pieces = think_router.process(filtered)
                 events, current_block_type, block_index = _emit_content_pieces(
-                    pieces, current_block_type, block_index
+                    pieces, current_block_type, block_index, thinking_buffer
                 )
                 for event in events:
                     yield event
@@ -3049,7 +3062,10 @@ async def _stream_anthropic_messages(
     remaining = tool_filter.flush()
     if remaining:
         events, current_block_type, block_index = _emit_content_pieces(
-            think_router.process(remaining), current_block_type, block_index
+            think_router.process(remaining),
+            current_block_type,
+            block_index,
+            thinking_buffer,
         )
         for event in events:
             yield event
@@ -3057,14 +3073,19 @@ async def _stream_anthropic_messages(
     flush_pieces = think_router.flush()
     if flush_pieces:
         events, current_block_type, block_index = _emit_content_pieces(
-            flush_pieces, current_block_type, block_index
+            flush_pieces, current_block_type, block_index, thinking_buffer
         )
         for event in events:
             yield event
 
-    # Close final content block
+    # Close final content block via the shared dispatcher so thinking blocks
+    # get signature_delta + content_block_stop and text/tool_use blocks
+    # get a bare stop — single source of truth with the mid-stream transition
+    # path. Handles the stream-ends-on-open-thinking case (max_tokens cap,
+    # clean stop with thinking but no text).
     if current_block_type is not None:
-        yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+        for ev in _emit_block_close(current_block_type, block_index, thinking_buffer):
+            yield ev
         block_index += 1
 
     # Check for tool calls in accumulated text

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -113,7 +113,7 @@ from .api.utils import (
     is_mllm_model,  # noqa: F401
 )
 from .engine import BaseEngine, BatchedEngine, GenerationOutput, SimpleEngine
-from .metrics import streaming_cap_fired_total
+from .metrics import streaming_cap_fired_total, thinking_signature_emitted_total
 from .tool_parsers import ToolParserManager
 
 logging.basicConfig(level=logging.INFO)
@@ -2690,6 +2690,61 @@ def _detect_starts_thinking(
     from_start = suffix[last_start:]
     has_close = any(et in from_start for et in end_tokens)
     return not has_close
+
+
+def _emit_block_close(
+    block_type: str,
+    block_index: int,
+    thinking_buffer: list[str],
+) -> list[str]:
+    """Emit the close-event sequence for a content block of the given type.
+
+    Dispatches on block_type:
+    - "thinking" → two events: signature_delta (Anthropic extended-thinking
+      streaming spec) then content_block_stop on the same index. Clears
+      thinking_buffer in place.
+    - "text" → one bare content_block_stop event. thinking_buffer untouched.
+    - anything else → raises ValueError so new block types can't silently
+      drop the signature contract.
+
+    Invariant 13 (UPSTREAM_PIN.md): every thinking content block — streaming
+    or non-streaming — MUST carry a signature. Any new signable block type
+    added to the Anthropic adapter MUST be routed through this dispatcher.
+    """
+    if block_type == "thinking":
+        signature = compute_thinking_signature("".join(thinking_buffer))
+        if not thinking_buffer:
+            # Empty thinking buffer at close time — legal per spec (signature
+            # is REQUIRED regardless of content), but unusual. Log once so
+            # an operator can correlate unexpected SHA256-of-empty signatures
+            # (`vllm-mlx:e3b0c44298fc1c149afbf4c8996fb924`) back to the
+            # emitting request. INFO level (not WARN) — empty thinking is
+            # legal; WARN would trip ops alerts on a keyword match.
+            logger.info(
+                "[streaming-signature] closing thinking block idx=%d with "
+                "empty buffer; emitting empty-text signature",
+                block_index,
+            )
+        sig_event = {
+            "type": "content_block_delta",
+            "index": block_index,
+            "delta": {"type": "signature_delta", "signature": signature},
+        }
+        stop_event = {"type": "content_block_stop", "index": block_index}
+        thinking_buffer.clear()
+        thinking_signature_emitted_total.inc()  # module-scope import, see Step 2.5
+        return [
+            f"event: content_block_delta\ndata: {json.dumps(sig_event)}\n\n",
+            f"event: content_block_stop\ndata: {json.dumps(stop_event)}\n\n",
+        ]
+    if block_type == "text":
+        stop_event = {"type": "content_block_stop", "index": block_index}
+        return [f"event: content_block_stop\ndata: {json.dumps(stop_event)}\n\n"]
+    raise ValueError(
+        f"_emit_block_close: unhandled block_type={block_type!r}. "
+        "Any new signable Anthropic block type MUST be added to this "
+        "dispatcher. See UPSTREAM_PIN.md invariant 13."
+    )
 
 
 def _emit_content_pieces(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -58,7 +58,11 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 # Import from new modular API
 # Re-export for backwards compatibility with tests
-from .api.anthropic_adapter import anthropic_to_openai, openai_to_anthropic
+from .api.anthropic_adapter import (
+    anthropic_to_openai,
+    compute_thinking_signature,
+    openai_to_anthropic,
+)
 from .api.anthropic_models import AnthropicRequest
 from .api.budget_ceiling import apply_server_thinking_token_budget_ceiling
 from .api.effort import EffortSource, ResolvedBudget, resolve_effort  # noqa: F401

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2696,6 +2696,8 @@ def _emit_block_close(
     block_type: str,
     block_index: int,
     thinking_buffer: list[str],
+    *,
+    msg_id: str | None = None,
 ) -> list[str]:
     """Emit the close-event sequence for a content block of the given type.
 
@@ -2710,6 +2712,15 @@ def _emit_block_close(
     Invariant 13 (UPSTREAM_PIN.md): every thinking content block — streaming
     or non-streaming — MUST carry a signature. Any new signable block type
     added to the Anthropic adapter MUST be routed through this dispatcher.
+
+    Args:
+        block_type: "thinking" | "text" (unknown types raise ValueError).
+        block_index: Current block index for the close event.
+        thinking_buffer: Caller-owned accumulator for thinking-block text.
+        msg_id: Optional Anthropic message id for log correlation. Passed
+            by `_stream_anthropic_messages` so that on-call can grep
+            `[streaming-signature]` log lines by user-facing msg_id. None
+            is acceptable for unit-test callers.
     """
     if block_type == "thinking":
         signature = compute_thinking_signature("".join(thinking_buffer))
@@ -2721,8 +2732,9 @@ def _emit_block_close(
             # emitting request. INFO level (not WARN) — empty thinking is
             # legal; WARN would trip ops alerts on a keyword match.
             logger.info(
-                "[streaming-signature] closing thinking block idx=%d with "
-                "empty buffer; emitting empty-text signature",
+                "[streaming-signature] msg_id=%s closing thinking block "
+                "idx=%d with empty buffer; emitting empty-text signature",
+                msg_id if msg_id is not None else "<unknown>",
                 block_index,
             )
         sig_event = {
@@ -2752,6 +2764,8 @@ def _emit_content_pieces(
     current_block_type: str | None,
     block_index: int,
     thinking_buffer: list[str],
+    *,
+    msg_id: str | None = None,
 ) -> tuple[list[str], str | None, int]:
     """Emit Anthropic SSE events for content pieces from the think router.
 
@@ -2770,6 +2784,9 @@ def _emit_content_pieces(
             cleared by _emit_block_close() when the block closes. The
             caller MUST allocate a fresh list at the top of each request's
             streaming coroutine. Sharing a buffer across requests is a bug.
+        msg_id: Optional Anthropic message id, passed through to
+            `_emit_block_close` for log correlation. None is acceptable
+            for unit-test callers that don't exercise the log path.
 
     Returns:
         (events, updated_block_type, updated_block_index). The final open
@@ -2781,7 +2798,10 @@ def _emit_content_pieces(
         if block_type != current_block_type:
             if current_block_type is not None:
                 events.extend(
-                    _emit_block_close(current_block_type, block_index, thinking_buffer)
+                    _emit_block_close(
+                        current_block_type, block_index, thinking_buffer,
+                        msg_id=msg_id,
+                    )
                 )
                 block_index += 1
             current_block_type = block_type
@@ -3053,7 +3073,8 @@ async def _stream_anthropic_messages(
                 # Stage 2: route thinking vs text
                 pieces = think_router.process(filtered)
                 events, current_block_type, block_index = _emit_content_pieces(
-                    pieces, current_block_type, block_index, thinking_buffer
+                    pieces, current_block_type, block_index, thinking_buffer,
+                    msg_id=msg_id,
                 )
                 for event in events:
                     yield event
@@ -3066,6 +3087,7 @@ async def _stream_anthropic_messages(
             current_block_type,
             block_index,
             thinking_buffer,
+            msg_id=msg_id,
         )
         for event in events:
             yield event
@@ -3073,7 +3095,8 @@ async def _stream_anthropic_messages(
     flush_pieces = think_router.flush()
     if flush_pieces:
         events, current_block_type, block_index = _emit_content_pieces(
-            flush_pieces, current_block_type, block_index, thinking_buffer
+            flush_pieces, current_block_type, block_index, thinking_buffer,
+            msg_id=msg_id,
         )
         for event in events:
             yield event
@@ -3084,7 +3107,9 @@ async def _stream_anthropic_messages(
     # path. Handles the stream-ends-on-open-thinking case (max_tokens cap,
     # clean stop with thinking but no text).
     if current_block_type is not None:
-        for ev in _emit_block_close(current_block_type, block_index, thinking_buffer):
+        for ev in _emit_block_close(
+            current_block_type, block_index, thinking_buffer, msg_id=msg_id,
+        ):
             yield ev
         block_index += 1
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -66,7 +66,6 @@ from .api.anthropic_adapter import (
 from .api.anthropic_models import AnthropicRequest
 from .api.budget_ceiling import apply_server_thinking_token_budget_ceiling
 from .api.effort import EffortSource, ResolvedBudget, resolve_effort  # noqa: F401
-from .api.thinking_policy import maybe_disable_thinking_for_qwen3_agent_first_turn
 from .api.models import (
     AssistantMessage,  # noqa: F401
     ChatCompletionChoice,  # noqa: F401
@@ -98,6 +97,7 @@ from .api.models import (
     Usage,  # noqa: F401
     VideoUrl,  # noqa: F401
 )
+from .api.thinking_policy import maybe_disable_thinking_for_qwen3_agent_first_turn
 from .api.tool_calling import (
     build_json_system_prompt,
     convert_tools_for_template,


### PR DESCRIPTION
## TL;DR

Anthropic `/v1/messages` **streaming** responses on Qwen3.5 / Qwen3.6 were emitting `thinking` content blocks with **no `signature` field**. Claude Code's client-side stream aggregator treats unsigned thinking as malformed and silently discards the `text` block that follows. Users saw:

```json
{"is_error": false, "result": "", "stop_reason": "end_turn"}
```

A hang-equivalent: inference succeeded, the assistant text was on the wire, and the client threw it on the floor without an error.

This is the promised streaming follow-up to PR #14, which added signatures on the non-streaming path.

## Root cause

- Non-streaming (PR #14, `6b580ba`) correctly attaches `signature = "vllm-mlx:<32hex>"` to thinking blocks.
- Streaming path (`_stream_anthropic_messages` / `_emit_content_pieces` in `vllm_mlx/server.py`) emitted `content_block_start` / `thinking_delta` / `content_block_stop` but **never** a `signature_delta` event before the stop, so the aggregated block had no `signature` key.
- Claude Code's streaming client: unsigned thinking → reject the whole assistant message → no text shown → empty `result`.

## Fix summary

- **Single source of truth for the signature formula.** New helper `compute_thinking_signature(thinking_text: str) -> str` in `vllm_mlx/api/anthropic_adapter.py`. The non-streaming path was refactored to call it — byte-identical output to PR #14.
- **`signature_delta` on streaming thinking block close.** New dispatcher `_emit_block_close(block_type, block_index, thinking_buffer, *, msg_id=None)` in `vllm_mlx/server.py`:
  - `thinking` → emit `signature_delta` then `content_block_stop`.
  - `text` → emit bare `content_block_stop`.
  - anything else → `ValueError` (so new signable block types can't silently drop the contract).
- **Buffer plumbing.** `_emit_content_pieces` now takes `thinking_buffer: list[str]` as a required 4th parameter plus optional `msg_id` kwarg. `_stream_anthropic_messages` allocates the buffer at coroutine top and threads it through all 3 mid-stream call sites and the final block close.
- **Observability.**
  - New counter `thinking_signature_emitted_total` in `vllm_mlx/metrics.py` (local `_Counter` pattern, matching existing style).
  - `[streaming-signature]` INFO log on empty-buffer close includes `msg_id` for on-call correlation (both mid-stream and final-close paths).

## Tests

20 unit tests in `tests/test_anthropic_streaming_thinking_signature.py` + 4 rebase sentinels in `tests/test_streaming_signature_rebase_sentinel.py` + 8 updated call sites in `tests/test_streaming_pipeline_integration.py`.

### Test plan

- [x] Unit: `compute_thinking_signature()` returns `vllm-mlx:<32hex>` for all inputs incl. empty string, whitespace, unicode, long text
- [x] Unit: non-streaming path produces byte-identical signature to pre-refactor (regression guard)
- [x] Unit: `_emit_block_close` thinking branch emits `signature_delta` then `content_block_stop` in that order
- [x] Unit: `_emit_block_close` text branch emits bare `content_block_stop` (no signature)
- [x] Unit: `_emit_block_close` unknown type raises `ValueError`
- [x] Unit: `thinking_signature_emitted_total` counter increments on every thinking close
- [x] Unit: empty `thinking_buffer` still emits signature (Claude Code needs it even for empty reasoning)
- [x] Unit: `[streaming-signature]` log carries `msg_id` when provided
- [x] Integration: full `_stream_anthropic_messages` pass through all 3 mid-stream call sites + final close
- [x] Integration: interleaved thinking/text blocks maintain correct `index` assignment through dispatcher
- [x] Spec conformance: emitted SSE sequence matches Anthropic `/v1/messages` streaming spec order
- [x] Rebase sentinels (4): guard against silent regressions if future rebases touch the 4 critical call sites
- [x] Full regression sweep: **173 passed** across 13 test files (unit + integration + e2e + edge cases)

## Rejected alternatives

**`--anthropic-emit-thinking-signatures` feature flag.** Considered to opt-in the new behavior. Rejected because:
- `signature_delta` only emits when the client opts into extended thinking upstream — non-opt-in clients never see thinking blocks at all.
- The speculative risk ("a hypothetical downstream SDK that parses thinking but chokes on signature") didn't justify the permanent config surface, the dead code path, or the test matrix doubling.
- Rollback path is `git revert` if a real-world regression surfaces — fast, clean, no stranded config.

Documented in the `## Unreleased` CHANGELOG entry.

## Out-of-scope notes

- **Pre-existing ruff violations in `server.py` and `anthropic_adapter.py` are NOT addressed by this PR.** This branch's ruff hygiene commit (`748df81`) fixes the 7 violations this PR *would have introduced*. The 13 pre-existing `server.py` violations (B008, B904, SIM105, F841, N806 on unrelated names) and 1 pre-existing `anthropic_adapter.py` E402 remain. If the repo's pre-commit hook runs the full `[tool.ruff.lint]` rule set, those pre-existing violations may block the hook — that's not a new regression from this PR and should be addressed in a dedicated style-sweep PR.
- **`.claude/` directory** is local editor config, pre-existing, not committed. Not in scope.

## Links

- Diagnostic doc (git-tracked as of `48885ed`): [`docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md`](docs/testing/2026-04-23-qwen3-streaming-thinking-missing-signature-silent-text-drop.md) — full wire-level proof + reproduction
- Invariant 13 (extended): [`UPSTREAM_PIN.md`](UPSTREAM_PIN.md) — now covers streaming + byte-parity + names specific test-id guards
- Related: #14 — non-streaming thinking signature (this PR completes the forecast follow-up)

## /dc process trail

- 4 planning-phase waves before implementation (all clean after v4)
- 2-stage review per implementation task (spec + code quality)
- 2 post-implementation waves:
  - Wave 1: 1 CRITICAL (rejected with gating-code-cited rationale) + 7 MEDIUM + 5 LOW; 4 accepted MEDIUM items shipped as the last 3 commits on this branch
  - Wave 2: CLEAN (0 CRITICAL / 0 MEDIUM, 2 LOW both resolved at PR time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>