### PR TITLE
feat(anthropic): fold_thinking_as_text for Claude Code SDK compat

### DIFF
--- a/tests/test_fold_thinking_as_text.py
+++ b/tests/test_fold_thinking_as_text.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the `fold_thinking_as_text` emitter option.
+
+Anthropic's thinking content block is a first-class SSE block type
+(`content_block_start` with `type: "thinking"` + `thinking_delta` events
++ `signature_delta` + `content_block_stop`). Most clients handle it fine.
+
+Claude Code's SDK (v2.1.118 observed) has a bug where a `thinking` block
+followed by a `text` block causes the text block's AssistantMessage to be
+dropped from the SDK output, leaving `.result = ''`. The wire bytes are
+correct — the SDK's dual-block assembly drops the second message.
+
+Workaround: fold `('thinking', text)` pieces into a single `text` block
+using inline `<think>...</think>` tags. Claude Code sees one text block,
+which it handles correctly. Clients that want the spec-correct thinking
+block can leave the flag off.
+
+This matches the pre-PR-#22 emission shape on Qwen3 (when thinking was
+folded into text as `<think>...</think>`) — it's a documented, known-good
+client-compatibility pattern that restores Claude Code support without
+breaking spec-correct clients.
+
+The flag is plumbed as a per-request option so proxies (e.g.
+hank-secure-llm's Anthropic proxy) can toggle it based on the downstream
+client family, rather than forcing a global server choice.
+"""
+
+import json
+
+import pytest
+
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+from vllm_mlx.server import _emit_content_pieces
+
+
+def _parse_events(events: list[str]) -> list[dict]:
+    """Parse SSE event strings into {event, data} dicts for assertion."""
+    out = []
+    for raw in events:
+        lines = raw.strip().split("\n")
+        assert lines[0].startswith("event: "), raw
+        assert lines[1].startswith("data: "), raw
+        out.append(
+            {
+                "event": lines[0][len("event: ") :],
+                "data": json.loads(lines[1][len("data: ") :]),
+            }
+        )
+    return out
+
+
+def _collect_text_content(parsed: list[dict]) -> str:
+    """Concatenate all text_delta text fields in order."""
+    return "".join(
+        e["data"]["delta"]["text"]
+        for e in parsed
+        if e["data"].get("type") == "content_block_delta"
+        and e["data"].get("delta", {}).get("type") == "text_delta"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The failing test: fold_thinking=True should produce a single text block
+# ---------------------------------------------------------------------------
+
+
+def test_fold_thinking_produces_single_text_block():
+    """With fold_thinking=True and mixed thinking+text pieces, the emitter
+    produces exactly ONE content_block_start (type=text), no thinking
+    block start, no signature_delta, no thinking_delta. All content goes
+    through text_delta events with <think>...</think> wrapping the
+    reasoning portion."""
+    pieces = [("thinking", "Let me think..."), ("text", "OK")]
+    thinking_buffer: list[str] = []
+    events, final_block_type, final_block_index = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+        fold_thinking=True,
+    )
+    parsed = _parse_events(events)
+
+    # Exactly one content_block_start, of type=text
+    starts = [e for e in parsed if e["data"]["type"] == "content_block_start"]
+    assert len(starts) == 1, f"expected 1 start, got {len(starts)}: {parsed}"
+    assert starts[0]["data"]["content_block"]["type"] == "text", parsed
+
+    # No signature_delta, no thinking_delta
+    for e in parsed:
+        delta_type = e["data"].get("delta", {}).get("type")
+        assert delta_type != "signature_delta", f"unexpected sig_delta: {parsed}"
+        assert delta_type != "thinking_delta", f"unexpected thinking_delta: {parsed}"
+
+    # Text content is think-wrapped reasoning + the plain text
+    assert _collect_text_content(parsed) == "<think>Let me think...</think>OK"
+
+
+def test_fold_thinking_multiple_thinking_chunks_single_wrapper():
+    """Multiple consecutive thinking pieces should produce a single
+    <think>...</think> wrapper, not one per piece."""
+    pieces = [
+        ("thinking", "Analyzing... "),
+        ("thinking", "step one. "),
+        ("thinking", "step two."),
+        ("text", "Done."),
+    ]
+    events, _, _ = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=[],
+        fold_thinking=True,
+    )
+    parsed = _parse_events(events)
+    text = _collect_text_content(parsed)
+    assert text == "<think>Analyzing... step one. step two.</think>Done."
+    assert text.count("<think>") == 1
+    assert text.count("</think>") == 1
+
+
+def test_fold_thinking_only_thinking_leaves_block_open_for_final_close():
+    """If pieces contain only thinking (no text yet), the text block stays
+    open — caller's final-close is responsible for emitting </think> and
+    content_block_stop. The emitter shouldn't close the block early."""
+    pieces = [("thinking", "Half-finished reasoning...")]
+    events, final_block_type, final_block_index = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=[],
+        fold_thinking=True,
+    )
+    parsed = _parse_events(events)
+    # Block is still text (fold_thinking maps thinking → text)
+    assert final_block_type == "text"
+    # No content_block_stop — caller handles that
+    assert not any(
+        e["data"]["type"] == "content_block_stop" for e in parsed
+    ), parsed
+    # The emitted text_delta opens <think> but doesn't close it
+    text = _collect_text_content(parsed)
+    assert text == "<think>Half-finished reasoning..."
+    assert "<think>" in text
+    assert "</think>" not in text
+
+
+def test_fold_thinking_off_preserves_current_behavior():
+    """With fold_thinking=False (or omitted), behavior is unchanged —
+    thinking still gets its own content_block_start with type=thinking."""
+    pieces = [("thinking", "foo"), ("text", "bar")]
+    events, _, _ = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=[],
+        # fold_thinking omitted — default False
+    )
+    parsed = _parse_events(events)
+    types = [
+        e["data"]["content_block"]["type"]
+        for e in parsed
+        if e["data"]["type"] == "content_block_start"
+    ]
+    assert types == ["thinking", "text"]
+
+
+def test_fold_thinking_final_close_emits_closing_tag_if_still_open():
+    """When `_emit_block_close` is called on a text block whose fold-mode
+    wrapper is still open (thinking_buffer has the sentinel), it must
+    emit a final `text_delta` carrying `</think>` BEFORE the
+    content_block_stop. Otherwise the client sees an unbalanced
+    `<think>` in its result field."""
+    from vllm_mlx.server import _emit_block_close
+
+    # Simulate: emitter is mid-<think>, no text piece ever arrived.
+    pieces = [("thinking", "Mid-stream reasoning that was cut off")]
+    thinking_buffer: list[str] = []
+    events, block_type, block_index = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+        fold_thinking=True,
+    )
+    # Now final-close: the wrapper is still open (buffer has sentinel).
+    assert thinking_buffer, "fold mode must keep sentinel so close can detect"
+    close_events = _emit_block_close(
+        block_type,
+        block_index,
+        thinking_buffer,
+        fold_thinking=True,
+    )
+    all_parsed = _parse_events(events + close_events)
+
+    # Last two events should be: text_delta with "</think>", then stop.
+    closing_deltas = [
+        e for e in all_parsed
+        if e["data"].get("type") == "content_block_delta"
+        and e["data"].get("delta", {}).get("type") == "text_delta"
+    ]
+    assert closing_deltas[-1]["data"]["delta"]["text"] == "</think>", all_parsed
+
+    stops = [e for e in all_parsed if e["data"].get("type") == "content_block_stop"]
+    assert len(stops) == 1, all_parsed
+
+    # No signature_delta in fold mode's close path.
+    for e in all_parsed:
+        assert e["data"].get("delta", {}).get("type") != "signature_delta"
+
+    # thinking_buffer cleared after close.
+    assert thinking_buffer == [], "close must clear the fold sentinel"
+
+
+def test_fold_thinking_final_close_no_open_wrapper_is_bare_stop():
+    """Final close on a fold-mode text block whose wrapper already closed
+    (buffer empty) should be a plain content_block_stop — no stray
+    </think>."""
+    from vllm_mlx.server import _emit_block_close
+
+    pieces = [("thinking", "reason"), ("text", "answer")]
+    thinking_buffer: list[str] = []
+    events, block_type, block_index = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=thinking_buffer,
+        fold_thinking=True,
+    )
+    assert thinking_buffer == [], "wrapper should have closed after text piece"
+    close_events = _emit_block_close(
+        block_type,
+        block_index,
+        thinking_buffer,
+        fold_thinking=True,
+    )
+    close_parsed = _parse_events(close_events)
+    assert len(close_parsed) == 1
+    assert close_parsed[0]["data"]["type"] == "content_block_stop"
+
+
+def test_anthropic_request_accepts_fold_thinking_in_output_config():
+    """The request schema plumbs `output_config.fold_thinking_as_text`
+    through validation without rejecting it."""
+    req = AnthropicRequest(
+        model="mlx-community/whatever",
+        max_tokens=100,
+        messages=[{"role": "user", "content": "hi"}],
+        output_config={"effort": "high", "fold_thinking_as_text": True},
+    )
+    assert req.output_config["fold_thinking_as_text"] is True
+    # Omitted is fine
+    req2 = AnthropicRequest(
+        model="mlx-community/whatever",
+        max_tokens=100,
+        messages=[{"role": "user", "content": "hi"}],
+        output_config={"effort": "high"},
+    )
+    assert "fold_thinking_as_text" not in req2.output_config
+
+
+def test_anthropic_request_rejects_non_bool_fold_thinking():
+    """Non-bool values for fold_thinking_as_text are rejected at ingress
+    rather than silently coerced — prevents truthy/falsy surprises."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        AnthropicRequest(
+            model="mlx-community/whatever",
+            max_tokens=100,
+            messages=[{"role": "user", "content": "hi"}],
+            output_config={"fold_thinking_as_text": "yes"},
+        )
+
+
+def test_fold_thinking_transition_from_text_to_thinking_and_back():
+    """When fold_thinking=True and pieces go text → thinking → text,
+    the wrappers should open/close in the middle of the text stream."""
+    pieces = [
+        ("text", "Before. "),
+        ("thinking", "Aside: reasoning."),
+        ("text", " After."),
+    ]
+    events, _, _ = _emit_content_pieces(
+        pieces,
+        current_block_type=None,
+        block_index=0,
+        thinking_buffer=[],
+        fold_thinking=True,
+    )
+    parsed = _parse_events(events)
+    # One content_block_start (text)
+    starts = [e for e in parsed if e["data"]["type"] == "content_block_start"]
+    assert len(starts) == 1 and starts[0]["data"]["content_block"]["type"] == "text"
+    text = _collect_text_content(parsed)
+    assert text == "Before. <think>Aside: reasoning.</think> After."

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -112,6 +112,16 @@ class AnthropicRequest(BaseModel):
                     f"output_config.effort={effort!r} is not a recognized "
                     f"level. Allowed: {sorted(ALLOWED_EFFORT_LEVELS)}"
                 )
+        # Optional vllm-mlx-patched extension: fold thinking blocks into the
+        # text block as inline `<think>…</think>` wrappers. Documented in
+        # `vllm_mlx/server.py:_emit_content_pieces`; see the fold-thinking
+        # emitter test file for rationale (Claude Code SDK client workaround).
+        fold = v.get("fold_thinking_as_text")
+        if fold is not None and not isinstance(fold, bool):
+            raise ValueError(
+                f"output_config.fold_thinking_as_text must be bool, got "
+                f"{type(fold).__name__}: {fold!r}"
+            )
         return v
 
     @field_validator("thinking")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2707,6 +2707,7 @@ def _emit_block_close(
     thinking_buffer: list[str],
     *,
     msg_id: str | None = None,
+    fold_thinking: bool = False,
 ) -> list[str]:
     """Emit the close-event sequence for a content block of the given type.
 
@@ -2715,6 +2716,10 @@ def _emit_block_close(
       streaming spec) then content_block_stop on the same index. Clears
       thinking_buffer in place.
     - "text" → one bare content_block_stop event. thinking_buffer untouched.
+      EXCEPT in fold_thinking mode, if `thinking_buffer` is non-empty (fold
+      sentinel signalling an unclosed `<think>` wrapper from a prior
+      `_emit_content_pieces` batch), emit a final `text_delta` carrying
+      `</think>` before the stop so the client sees a balanced wrapper.
     - anything else → raises ValueError so new block types can't silently
       drop the signature contract.
 
@@ -2759,13 +2764,81 @@ def _emit_block_close(
             f"event: content_block_stop\ndata: {json.dumps(stop_event)}\n\n",
         ]
     if block_type == "text":
+        events: list[str] = []
+        if fold_thinking and thinking_buffer:
+            # Unclosed `<think>` wrapper from a prior batch — emit the
+            # closing tag as a final text_delta so the client sees balanced
+            # tags. Bare text-block close otherwise.
+            closing_delta = {
+                "type": "content_block_delta",
+                "index": block_index,
+                "delta": {"type": "text_delta", "text": "</think>"},
+            }
+            events.append(
+                f"event: content_block_delta\ndata: {json.dumps(closing_delta)}\n\n"
+            )
+            thinking_buffer.clear()
         stop_event = {"type": "content_block_stop", "index": block_index}
-        return [f"event: content_block_stop\ndata: {json.dumps(stop_event)}\n\n"]
+        events.append(
+            f"event: content_block_stop\ndata: {json.dumps(stop_event)}\n\n"
+        )
+        return events
     raise ValueError(
         f"_emit_block_close: unhandled block_type={block_type!r}. "
         "Any new signable Anthropic block type MUST be added to this "
         "dispatcher. See UPSTREAM_PIN.md invariant 13."
     )
+
+
+def _fold_thinking_pieces(
+    pieces: list[tuple[str, str]],
+    *,
+    caller_in_think: bool,
+) -> tuple[list[tuple[str, str]], bool]:
+    """Rewrite `('thinking', text)` pieces into `('text', '<think>…</think>')`
+    text pieces so downstream emission stays inside a single text block.
+
+    Used when the `fold_thinking` option is enabled — see
+    `_emit_content_pieces` and the module-level docstring on why this is
+    needed (Claude Code SDK drops text blocks that follow spec-correct
+    thinking blocks; folding preserves the reasoning content visibly while
+    keeping the wire response to a single text block).
+
+    The `<think>` tag opens on the first thinking piece and closes when
+    the stream transitions to non-thinking (or at final close, which the
+    caller drives). Consecutive thinking pieces share one wrapper.
+
+    Args:
+        pieces: list of (block_type, text) pairs from the think router.
+        caller_in_think: True if the caller is already inside an unclosed
+            `<think>` wrapper from a prior call — in which case a leading
+            thinking piece should NOT emit a new `<think>` opener. This
+            exists so multi-call streams (one `_emit_content_pieces` call
+            per router output batch) don't double-open the wrapper.
+
+    Returns:
+        (translated, in_think_after) where `translated` is a list of
+        `('text', text)` pairs ready for the standard emission loop, and
+        `in_think_after` reports whether the wrapper is still open at end
+        of this batch (caller stores it for the next call, or emits
+        `</think>` on final close).
+    """
+    translated: list[tuple[str, str]] = []
+    in_think = caller_in_think
+    for block_type, text in pieces:
+        if block_type == "thinking":
+            if not in_think:
+                translated.append(("text", "<think>" + text))
+                in_think = True
+            else:
+                translated.append(("text", text))
+        else:
+            if in_think:
+                translated.append(("text", "</think>" + text))
+                in_think = False
+            else:
+                translated.append((block_type, text))
+    return translated, in_think
 
 
 def _emit_content_pieces(
@@ -2775,6 +2848,7 @@ def _emit_content_pieces(
     thinking_buffer: list[str],
     *,
     msg_id: str | None = None,
+    fold_thinking: bool = False,
 ) -> tuple[list[str], str | None, int]:
     """Emit Anthropic SSE events for content pieces from the think router.
 
@@ -2793,9 +2867,24 @@ def _emit_content_pieces(
             cleared by _emit_block_close() when the block closes. The
             caller MUST allocate a fresh list at the top of each request's
             streaming coroutine. Sharing a buffer across requests is a bug.
+
+            When `fold_thinking=True`, this buffer is used as a state
+            signal: non-empty at entry means the caller is mid-`<think>`
+            wrapper from a prior call. Upon close of thinking via
+            transition-to-text, the buffer is cleared here (not via
+            `_emit_block_close`, since no thinking block is opened).
         msg_id: Optional Anthropic message id, passed through to
             `_emit_block_close` for log correlation. None is acceptable
             for unit-test callers that don't exercise the log path.
+        fold_thinking: When True, `('thinking', text)` pieces are folded
+            into a single text block with inline `<think>…</think>`
+            wrappers instead of being emitted as separate Anthropic
+            thinking content blocks. No `thinking_delta` or
+            `signature_delta` events are produced in this mode. This is
+            a client-compatibility shim for SDKs (e.g. Claude Code
+            v2.1.x) whose multi-content-block assembly drops text blocks
+            that follow spec-correct thinking blocks. Default False
+            preserves spec-correct emission.
 
     Returns:
         (events, updated_block_type, updated_block_index). The final open
@@ -2803,6 +2892,17 @@ def _emit_content_pieces(
         final-close owns that.
     """
     events = []
+    if fold_thinking:
+        pieces, still_in_think = _fold_thinking_pieces(
+            pieces, caller_in_think=bool(thinking_buffer)
+        )
+        # Keep thinking_buffer as an "inside <think>" flag: len > 0 iff
+        # the wrapper is still open. Any prior entries (from a previous
+        # call) no longer represent thinking content in this mode, so
+        # normalize to a single sentinel when still open.
+        thinking_buffer.clear()
+        if still_in_think:
+            thinking_buffer.append("<fold_sentinel>")
     for block_type, text in pieces:
         if block_type != current_block_type:
             if current_block_type is not None:
@@ -2854,6 +2954,15 @@ async def _stream_anthropic_messages(
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
+
+    # Opt-in client-compatibility shim: fold `<think>` reasoning into the
+    # text block with inline tags instead of emitting a separate Anthropic
+    # `thinking` content block. Needed by clients (Claude Code v2.1.x) whose
+    # multi-content-block assembly drops text blocks that follow spec-correct
+    # thinking blocks. Per-request so the proxy can toggle it per downstream
+    # client; default off preserves Anthropic-spec emission.
+    _oc = anthropic_request.output_config or {}
+    fold_thinking = bool(_oc.get("fold_thinking_as_text")) if isinstance(_oc, dict) else False
 
     # Extract messages for engine
     messages, images, videos = extract_multimodal_content(
@@ -3089,6 +3198,7 @@ async def _stream_anthropic_messages(
                     block_index,
                     thinking_buffer,
                     msg_id=msg_id,
+                    fold_thinking=fold_thinking,
                 )
                 for event in events:
                     yield event
@@ -3102,6 +3212,7 @@ async def _stream_anthropic_messages(
             block_index,
             thinking_buffer,
             msg_id=msg_id,
+            fold_thinking=fold_thinking,
         )
         for event in events:
             yield event
@@ -3114,6 +3225,7 @@ async def _stream_anthropic_messages(
             block_index,
             thinking_buffer,
             msg_id=msg_id,
+            fold_thinking=fold_thinking,
         )
         for event in events:
             yield event
@@ -3129,6 +3241,7 @@ async def _stream_anthropic_messages(
             block_index,
             thinking_buffer,
             msg_id=msg_id,
+            fold_thinking=fold_thinking,
         ):
             yield ev
         block_index += 1


### PR DESCRIPTION
## Problem

Claude Code's SDK (v2.1.118 observed) has a bug where a response carrying separate `thinking` + `text` content blocks loses the text block during multi-message assembly, leaving `.result = ''`. Wire bytes are correct — verified via direct curl SSE dumps through `hank-secure-llm`'s dogfood proxy.

This makes every non-tool Qwen3 scenario fail end-to-end in Claude Code even though the proxy + upstream behave correctly.

## Why Gemma sidesteps it

`Gemma4ReasoningParser` only activates when the model emits `<|channel>thought` sentinel tokens. On typical harness prompts ("Reply with exactly OK", "what is 13 × 17?") it stays dormant → text-only response → Claude Code's buggy dual-block path never fires → 6/6 pass.

Qwen3 emits `<think>` on almost every prompt → hits the bug consistently.

## Fix

New `output_config.fold_thinking_as_text` boolean. Default false (spec-correct emission for proper clients). When true, the emitter folds `('thinking', text)` pieces into a single text block with inline `<think>…</think>` wrappers — matches the pre-`22c9c6a` Qwen3 shape that worked in Claude Code.

## Plumbing

- New `_fold_thinking_pieces()` helper — translates thinking → text pieces with balanced wrappers
- `_emit_content_pieces(..., fold_thinking)` — pre-translates pieces before existing loop
- `_emit_block_close(..., fold_thinking)` — emits `</think>` text_delta before stop when sentinel still open (stream-end-mid-thinking)
- `_stream_anthropic_messages` reads the option once and threads through all 3 call sites
- `AnthropicRequest.output_config` validator accepts + rejects non-bool at ingress

## Tests

9 new in `tests/test_fold_thinking_as_text.py`:
- single-text-block folding (no thinking_delta / no signature_delta on wire)
- consecutive thinking chunks get one wrapper
- stream-end-mid-thinking final close emits `</think>`
- fold=False preserves spec-correct behavior (non-regression guard)
- text → thinking → text transitions inline
- AnthropicRequest accepts/rejects the field correctly

**1529 existing tests continue to pass.** (pre-existing `test_bench_compile.py` mlx-lm API failure is unrelated)

## Test plan

- [ ] Deploy and restart Qwen3.5 + Qwen3.6 model processes
- [ ] Direct curl verification:
  ```bash
  curl -sS -N -X POST .../v1/messages -d '{..., "output_config":{"fold_thinking_as_text":true}, "thinking":{"type":"adaptive"}}' | grep -c 'thinking_delta\|signature_delta\|text_delta'
  # expect: 0 thinking_delta, 0 signature_delta, N text_delta (with <think>/</think> inline)
  ```
- [ ] hank-secure-llm: add `output_config.fold_thinking_as_text: true` in proxy rewrite for Claude-Code-bound requests (separate PR)
- [ ] Run `model_qa` harness — expect Qwen3.5/3.6 to flip from 2/7 PASS to 7/7 (matching Gemma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)