### PR TITLE
docs+test: pin mlx-lm-v4 fork for deepseek_v4 + sentinel

### DIFF
--- a/UPSTREAM_PIN.md
+++ b/UPSTREAM_PIN.md
@@ -354,6 +354,81 @@ defensive `for p in (self.logits_processors[e] or []):` fix in
 `GenerationBatch._step()`.  Until upstream lands it, our caller-side
 contract is the only defense.
 
+### Invariant 19: `mlx-lm` install MUST include `deepseek_v4` model class (added 2026-04-28)
+
+The `vllm-mlx` conda env's `mlx-lm` install MUST resolve
+`mlx_lm.models.deepseek_v4` at import time. The upstream PyPI package
+(`mlx-lm 0.31.3`) does NOT ship this module — only `deepseek`,
+`deepseek_v2`, `deepseek_v3`, `deepseek_v32`. Without `deepseek_v4`,
+`vllm-mlx serve mlx-community/DeepSeek-V4-Flash-4bit` (or any other
+`config.json` with `model_type: deepseek_v4`) hard-fails at startup
+with:
+
+    ModuleNotFoundError: No module named 'mlx_lm.models.deepseek_v4'
+    ValueError: Model type deepseek_v4 not supported.
+    ERROR:    Application startup failed. Exiting.
+
+**Current pin (editable install):**
+
+- **Source:** `https://github.com/jackneil/mlx-lm-1.git`
+- **Branch:** `fix/deepseek-v4-decode-cache`
+- **HEAD SHA:** `2673e367f143b8632bd026744e1bf183a674f670` (`fix(deepseek_v4): with-cache decode parity — 4 root causes`)
+- **Local clone:** `/Users/jackneil/Github/mlx-lm-v4`
+- **Conda env wiring:** `/opt/homebrew/Caskroom/miniconda/base/envs/vllm-mlx/lib/python3.12/site-packages/__editable__.mlx_lm-0.31.3.pth`
+  (`pip install -e /Users/jackneil/Github/mlx-lm-v4`)
+
+**Why an editable install instead of a `pyproject.toml` git+ pin
+(invariant 17 pattern):** the deepseek_v4 model class is under active
+development in this fork — bug fixes (e.g. the 4-root-cause cache-vs-
+no-cache logit parity fix at `2673e36`) need to be tested locally
+without re-publishing a pip-installable artifact. The editable install
+keeps `import mlx_lm.models.deepseek_v4` resolving against the working
+tree.
+
+**Forge dependency:** `hank_llm_arena/forge/validators/deepseek_v4.py`
+(arena's HF→MLX convert pipeline) imports `from mlx_lm.models import
+deepseek_v4` at module load and uses `from mlx_lm import load` for
+artifact-parity checks. Forge does NOT ship the model class — it
+assumes it is present in the env. Same constraint applies.
+
+**Failure modes if this pin regresses:**
+
+1. `pip install -U mlx-lm` (or any `pip install` that resolves a
+   transitive `mlx-lm` dep) silently overwrites the editable install
+   with PyPI's `mlx-lm 0.31.3`, removing `deepseek_v4`. DeepSeek model
+   starts hard-fail at the first request after restart. The arena's
+   /admin/models will show the model as `stopped` with no PID.
+
+2. The `mlx-lm-v4` working tree is checked out to a branch without
+   `mlx_lm/models/deepseek_v4.py` (e.g. accidental `git checkout main`).
+   Same symptom — same diagnosis.
+
+**Sentinel test (recommended):** add a contract test parallel to
+`tests/test_mlx_lm_arrays_cache_concurrent.py` that asserts:
+
+    import mlx_lm.models.deepseek_v4  # noqa: F401
+    from mlx_lm.utils import _get_classes
+    cls, args = _get_classes(config={'model_type': 'deepseek_v4'})
+    assert cls.__module__ == 'mlx_lm.models.deepseek_v4'
+
+Failure mode is the exact `ModuleNotFoundError` chain users hit at
+serve-time, so the sentinel catches PyPI overwrites before the next
+DeepSeek serve attempt.
+
+**Drop-back path:** when upstream `ml-explore/mlx-lm` accepts the
+deepseek_v4 model class on `main`, drop the editable install in favor
+of a plain `mlx-lm>=N.N.N` pin in invariant 17's `pyproject.toml`.
+Keep the sentinel; it remains the long-term guard against a future
+mlx-lm regression of this architecture.
+
+**History:** Pre-2026-04-28 the env had stock PyPI `mlx-lm 0.31.3`,
+which crashed every DeepSeek-V4-Flash-4bit start. The editable install
+of `jackneil/mlx-lm-1@fix/deepseek-v4-decode-cache` was wired in some
+time before 2026-04-28; this invariant documents that wiring so it
+survives future env rebuilds. Diagnosis trace at
+`hank-llm-arena/data/logs/mlx-community--DeepSeek-V4-Flash-4bit.log`
+(stale Apr 25, pre-fix).
+
 ## Rebase checklist
 
 When merging upstream changes into this fork:

--- a/tests/test_mlx_lm_deepseek_v4_present.py
+++ b/tests/test_mlx_lm_deepseek_v4_present.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rebase / env-state sentinel for the mlx_lm.models.deepseek_v4 module.
+
+Pinned by UPSTREAM_PIN.md invariant #19.
+
+Upstream PyPI mlx-lm 0.31.3 ships only ``deepseek``, ``deepseek_v2``,
+``deepseek_v3``, and ``deepseek_v32`` model classes. The ``deepseek_v4``
+class lives in jackneil/mlx-lm-1@fix/deepseek-v4-decode-cache (cloned
+locally at /Users/jackneil/Github/mlx-lm-v4) and reaches the vllm-mlx
+conda env via an editable install (.pth). Without this editable install
+in place, ``vllm-mlx serve mlx-community/DeepSeek-V4-Flash-4bit`` (or any
+other config.json with ``model_type: deepseek_v4``) hard-fails at startup:
+
+    ModuleNotFoundError: No module named 'mlx_lm.models.deepseek_v4'
+    ValueError: Model type deepseek_v4 not supported.
+    ERROR:    Application startup failed. Exiting.
+
+Forge's ``hank_llm_arena/forge/validators/deepseek_v4.py`` validator (in
+the arena repo) does ``from mlx_lm.models import deepseek_v4`` at module
+load time and ``from mlx_lm import load`` for artifact-parity validation.
+Forge does not ship the model class — it depends on this editable install.
+
+How this sentinel fails:
+
+1. ``pip install -U mlx-lm`` (or any transitive install resolving mlx-lm
+   from PyPI) silently overwrites the editable install. ``mlx_lm.__file__``
+   moves out of /Users/jackneil/Github/mlx-lm-v4/, the deepseek_v4 module
+   disappears, and DeepSeek serving regresses without any other test
+   noticing.
+2. The mlx-lm-v4 working tree is checked out to a branch that doesn't
+   carry ``mlx_lm/models/deepseek_v4.py`` (e.g. accidental
+   ``git checkout main`` in the local clone).
+
+Fix path on either failure: re-run the editable install:
+
+    pip install -e /Users/jackneil/Github/mlx-lm-v4
+
+If this file fails in CI, do NOT merge — DeepSeek serving will be silently
+broken until the first user request crashes.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_mlx_lm_deepseek_v4_module_imports():
+    """Module must be importable for vllm-mlx to load DeepSeek V4 weights."""
+    try:
+        importlib.import_module("mlx_lm.models.deepseek_v4")
+    except ModuleNotFoundError as e:  # pragma: no cover
+        pytest.fail(
+            "mlx_lm.models.deepseek_v4 is missing — invariant #19 broken. "
+            "The vllm-mlx conda env's mlx-lm install does NOT include this "
+            "architecture. Re-install the editable fork: "
+            "`pip install -e /Users/jackneil/Github/mlx-lm-v4`. "
+            f"Underlying error: {e}"
+        )
+
+
+def test_mlx_lm_get_classes_resolves_deepseek_v4():
+    """The exact code path that vllm-mlx hits at server startup must succeed."""
+    from mlx_lm.utils import _get_classes
+
+    try:
+        cls, args_cls = _get_classes(config={"model_type": "deepseek_v4"})
+    except ValueError as e:  # pragma: no cover
+        pytest.fail(
+            "mlx_lm.utils._get_classes failed to resolve model_type='deepseek_v4'. "
+            "This is the same crash users hit at vllm-mlx serve time. "
+            f"See invariant #19 in UPSTREAM_PIN.md. Underlying error: {e}"
+        )
+
+    assert cls.__module__ == "mlx_lm.models.deepseek_v4", (
+        f"Expected resolved class module to be 'mlx_lm.models.deepseek_v4', "
+        f"got {cls.__module__!r}. This usually means a different mlx-lm "
+        f"install is being picked up — check mlx_lm.__file__ resolves to "
+        f"/Users/jackneil/Github/mlx-lm-v4/mlx_lm/."
+    )
+    assert args_cls.__module__ == "mlx_lm.models.deepseek_v4"
+
+
+def test_editable_install_points_at_mlx_lm_v4():
+    """mlx_lm package must resolve from the local fork, not PyPI install.
+
+    A passing import (test above) is necessary but not sufficient — a
+    future upstream PyPI release that ships its OWN deepseek_v4 module
+    would also pass the import test, but might lack the cache-parity
+    fixes the fork carries (HEAD 2673e367 at the time of pinning). When
+    upstream catches up, drop this test and the editable install (per
+    UPSTREAM_PIN.md invariant 19's drop-back path).
+    """
+    import mlx_lm
+
+    expected_marker = "/Users/jackneil/Github/mlx-lm-v4/"
+    if expected_marker not in (mlx_lm.__file__ or ""):  # pragma: no cover
+        pytest.fail(
+            f"mlx_lm.__file__ = {mlx_lm.__file__!r} does NOT resolve under "
+            f"{expected_marker}. The editable install of the mlx-lm-v4 fork "
+            f"has been overwritten (likely by `pip install -U mlx-lm` or a "
+            f"transitive install). Re-run: "
+            f"`pip install -e /Users/jackneil/Github/mlx-lm-v4`. "
+            f"See invariant #19 in UPSTREAM_PIN.md."
+        )


### PR DESCRIPTION
## Summary

Companion to https://github.com/hank-ai/hank-llm-arena/pull/45 (post-merge regression sweep on the arena side). The original trigger for that work was a DeepSeek-V4-Flash-4bit serve attempt that hard-failed:

```
ModuleNotFoundError: No module named 'mlx_lm.models.deepseek_v4'
ValueError: Model type deepseek_v4 not supported.
```

Diagnosis: upstream PyPI `mlx-lm 0.31.3` ships only `deepseek`, `deepseek_v2`, `deepseek_v3`, `deepseek_v32`. The `deepseek_v4` model class lives in `jackneil/mlx-lm-1@fix/deepseek-v4-decode-cache` (HEAD `2673e367`) and reaches the vllm-mlx conda env via an editable install. The env was repaired between the Apr 25 failure log and the regression-sweep session — but UPSTREAM_PIN.md didn't document the wiring, leaving it vulnerable to silent regression on any future `pip install -U`.

## Two commits

1. **`97ef27e` `docs(UPSTREAM_PIN): pin mlx-lm-v4 fork for deepseek_v4 model class`** — adds invariant 19 with the same structure as invariants 5-18 (current pin SHA, failure modes, drop-back path when upstream catches up, history). Section explains why it's an editable install rather than the `pyproject.toml` git+ pattern (active dev on cache-parity fixes).

2. **`44357a9` `test(deepseek_v4): write the sentinel that invariant 19 only "recommended"`** — DCR pre-mortem flagged invariant 19 as the highest-severity finding because the original write-up only said "Sentinel test (recommended)" without writing it. This commit provides the contract the invariant promised:
   - `test_mlx_lm_deepseek_v4_module_imports` — bare `import mlx_lm.models.deepseek_v4`
   - `test_mlx_lm_get_classes_resolves_deepseek_v4` — exercises `mlx_lm.utils._get_classes` (the exact path that crashes vllm-mlx serve)
   - `test_editable_install_points_at_mlx_lm_v4` — asserts `mlx_lm.__file__` resolves under `/Users/jackneil/Github/mlx-lm-v4/`. This guards against a future PyPI release shipping deepseek_v4 with worse cache-parity behavior than the fork.

## Failure modes the sentinel catches

- `pip install -U mlx-lm` (or transitive install) silently overwrites the editable install → tests 1+2+3 all fail
- The local `mlx-lm-v4` clone gets checked out to a branch without the deepseek_v4 module → tests 1+2 fail
- Forge's `hank_llm_arena/forge/validators/deepseek_v4.py` (in the arena repo, depends on this) silently drops out of its registry on import error — without this CI sentinel that failure has no surface

## Test plan

- [x] `pytest tests/test_mlx_lm_deepseek_v4_present.py -v` — 3/3 passing on current env.
- [ ] Wire into CI's `test-apple-silicon` workflow alongside `test_mlx_lm_arrays_cache_concurrent.py` (separate PR; this one only adds the test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)