### PR TITLE
fix(memory): idle-branch cache reap + coordinated wired-limit

### DIFF
--- a/tests/test_engine_core_idle_reap.py
+++ b/tests/test_engine_core_idle_reap.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the EngineCore idle-branch cache reap.
+
+Background: vllm-mlx processes accumulate Metal-pinned (wired) pages over
+hours of uptime even when idle (no requests). The Metal allocator only
+returns pages on `mx.clear_cache()`, but the existing call sites at
+engine_core.py:229 and :269 live on the ACTIVE branch of the main loop.
+An idle process never calls `mx.clear_cache()` and slowly leaks wired
+pages — the proximate cause of the cascading hang documented in
+mlx-lm/issues/883 and /1015.
+
+These tests pin the idle-branch reap behavior:
+
+  - reap fires when enough time has passed since the last reap
+  - reap is a no-op when called more frequently than the interval
+  - the interval is env-configurable via VLLM_MLX_IDLE_REAP_INTERVAL_S
+
+The reap is gated on `mx.metal.is_available()` so the tests mock that
+plus `mx.clear_cache` to avoid requiring a Metal device.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx import engine_core
+
+
+# ---------------------------------------------------------------------------
+# _maybe_reap_idle_cache predicate
+# ---------------------------------------------------------------------------
+
+
+class _FakeEngine:
+    """Minimal stand-in for EngineCore exposing only the reap state.
+
+    Tests call _maybe_reap_idle_cache as an unbound method against this.
+    """
+    def __init__(self):
+        self._last_idle_reap_ts: float = 0.0
+
+
+def test_idle_reap_fires_after_interval():
+    fake = _FakeEngine()
+    with patch.object(engine_core.mx.metal, "is_available", return_value=True), \
+         patch.object(engine_core.mx, "clear_cache") as clear_mock:
+        result = engine_core.EngineCore._maybe_reap_idle_cache(fake, now=100.0)
+    assert result is True
+    assert clear_mock.call_count == 1
+    assert fake._last_idle_reap_ts == 100.0
+
+
+def test_idle_reap_skips_within_interval(monkeypatch):
+    monkeypatch.setattr(engine_core, "IDLE_REAP_INTERVAL_S", 30.0)
+    fake = _FakeEngine()
+    fake._last_idle_reap_ts = 100.0
+    with patch.object(engine_core.mx.metal, "is_available", return_value=True), \
+         patch.object(engine_core.mx, "clear_cache") as clear_mock:
+        result = engine_core.EngineCore._maybe_reap_idle_cache(fake, now=120.0)
+    assert result is False, "second call within interval should be a no-op"
+    assert clear_mock.call_count == 0
+
+
+def test_idle_reap_fires_again_after_interval_elapses(monkeypatch):
+    monkeypatch.setattr(engine_core, "IDLE_REAP_INTERVAL_S", 30.0)
+    fake = _FakeEngine()
+    fake._last_idle_reap_ts = 100.0
+    with patch.object(engine_core.mx.metal, "is_available", return_value=True), \
+         patch.object(engine_core.mx, "clear_cache") as clear_mock:
+        # 100.0 + 31s > interval — should fire
+        result = engine_core.EngineCore._maybe_reap_idle_cache(fake, now=131.0)
+    assert result is True
+    assert clear_mock.call_count == 1
+    assert fake._last_idle_reap_ts == 131.0
+
+
+def test_idle_reap_no_op_when_metal_unavailable():
+    fake = _FakeEngine()
+    with patch.object(engine_core.mx.metal, "is_available", return_value=False), \
+         patch.object(engine_core.mx, "clear_cache") as clear_mock:
+        result = engine_core.EngineCore._maybe_reap_idle_cache(fake, now=100.0)
+    # Returning True only means "the time gate fired"; we expect clear_cache
+    # to be skipped when metal isn't available, but the timestamp still
+    # advances so we don't keep spinning the gate every tick.
+    assert clear_mock.call_count == 0
+    assert fake._last_idle_reap_ts == 100.0
+
+
+def test_idle_reap_interval_env_configurable(monkeypatch):
+    """IDLE_REAP_INTERVAL_S is set from VLLM_MLX_IDLE_REAP_INTERVAL_S env."""
+    monkeypatch.setenv("VLLM_MLX_IDLE_REAP_INTERVAL_S", "5")
+    # Force re-read of the constant (module-scope env reads happen at import)
+    import importlib
+    importlib.reload(engine_core)
+    try:
+        assert engine_core.IDLE_REAP_INTERVAL_S == 5.0
+    finally:
+        # Restore default for other tests
+        monkeypatch.delenv("VLLM_MLX_IDLE_REAP_INTERVAL_S", raising=False)
+        importlib.reload(engine_core)
+
+
+def test_idle_reap_clear_cache_exception_does_not_propagate():
+    """If clear_cache raises (rare but possible during heavy contention),
+    the loop must not crash. Swallow + log."""
+    fake = _FakeEngine()
+    with patch.object(engine_core.mx.metal, "is_available", return_value=True), \
+         patch.object(engine_core.mx, "clear_cache",
+                      side_effect=RuntimeError("metal busy")):
+        # Should not raise.
+        result = engine_core.EngineCore._maybe_reap_idle_cache(fake, now=100.0)
+    # Whether result is True or False is implementation-defined; the
+    # important contract is no exception escapes.
+    assert isinstance(result, bool)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -328,8 +328,17 @@ class BatchedEngine(BaseEngine):
                 )
 
         # Set Metal memory limits to make allocation failures graceful
-        # instead of fatal Metal command buffer errors (SIGABRT)
+        # instead of fatal Metal command buffer errors (SIGABRT).
+        #
+        # Env knobs (mlx-lm#883/#1015 — wired-page accumulation):
+        # - VLLM_MLX_CACHE_LIMIT_BYTES: cap on Metal cache (default 32 GB).
+        #   Lower values reduce maximum wired-page ceiling per process.
+        # - VLLM_MLX_NUM_SERVERS: divisor for the memory limit when N servers
+        #   share a host (default 1). Each process limits to
+        #   max_recommended/N so 9 sibling servers don't each request 90% of
+        #   physical RAM.
         try:
+            import os
             import mlx.core as mx
 
             if mx.metal.is_available():
@@ -338,15 +347,19 @@ class BatchedEngine(BaseEngine):
                     "max_recommended_working_set_size",
                     device_info.get("memory_size", 0),
                 )
+                num_servers = max(1, int(os.getenv("VLLM_MLX_NUM_SERVERS", "1")))
+                cache_limit_bytes = int(
+                    os.getenv("VLLM_MLX_CACHE_LIMIT_BYTES", str(32 * 1024 * 1024 * 1024))
+                )
                 if max_recommended > 0:
-                    soft_limit = int(max_recommended * 0.90)
+                    soft_limit = int((max_recommended * 0.90) / num_servers)
                     mx.set_memory_limit(soft_limit)
-                    mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # 32GB
+                    mx.set_cache_limit(cache_limit_bytes)
                     logger.info(
                         f"Metal memory limits set: "
                         f"allocation_limit={soft_limit / 1e9:.1f}GB "
-                        f"(90% of {max_recommended / 1e9:.1f}GB), "
-                        f"cache_limit=32GB"
+                        f"(90% of {max_recommended / 1e9:.1f}GB / {num_servers} servers), "
+                        f"cache_limit={cache_limit_bytes / 1e9:.1f}GB"
                     )
         except Exception as e:
             logger.warning(f"Failed to set Metal memory limits: {e}")

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -13,6 +13,7 @@ The design follows vLLM's engine architecture adapted for MLX.
 
 import asyncio
 import logging
+import os
 import time
 import uuid
 from dataclasses import dataclass
@@ -27,6 +28,16 @@ from .model_registry import get_registry
 from .mlx_streams import bind_generation_streams
 
 logger = logging.getLogger(__name__)
+
+
+# Idle-branch cache reap interval (seconds). When the engine loop has no
+# requests, the active-branch `mx.clear_cache()` calls (engine_core.py:229,
+# :269) never fire, so the Metal allocator never returns wired pages.
+# Production users hit this as a slow drift toward unrecoverable wired-page
+# pressure (mlx-lm/issues/883, /1015). Reaping every 30s while idle is
+# effectively free (there's no active scheduling to disturb) and keeps the
+# wired-page count bounded.
+IDLE_REAP_INTERVAL_S: float = float(os.getenv("VLLM_MLX_IDLE_REAP_INTERVAL_S", "30"))
 
 
 @dataclass
@@ -116,7 +127,35 @@ class EngineCore:
         self._engine_loop_last_error: Optional[str] = None
         self._engine_loop_error_streak: int = 0
 
+        # Idle-branch cache-reap timestamp; see _maybe_reap_idle_cache.
+        self._last_idle_reap_ts: float = 0.0
+
         logger.debug(f"Engine {self._engine_id} initialized")
+
+    def _maybe_reap_idle_cache(self, now: float) -> bool:
+        """Periodic Metal cache reap for the idle branch of the engine loop.
+
+        The active branch already calls `mx.clear_cache()` at engine_core.py:229
+        and :269. When the scheduler has no requests, neither fires, and the
+        Metal allocator slowly accumulates wired pages it would otherwise
+        return. Reap every IDLE_REAP_INTERVAL_S seconds while idle to bound
+        the wired-page footprint.
+
+        Returns True if the time gate fired this call (regardless of whether
+        clear_cache itself ran or raised — the timestamp advances either way
+        so we don't spin the gate every loop tick).
+        """
+        if now - self._last_idle_reap_ts < IDLE_REAP_INTERVAL_S:
+            return False
+        self._last_idle_reap_ts = now
+        try:
+            if mx.metal.is_available():
+                mx.clear_cache()
+        except Exception as e:
+            # Best-effort: if Metal is contended or briefly unavailable, log
+            # and move on. The next idle tick retries.
+            logger.warning(f"[idle-reap] mx.clear_cache failed: {e}")
+        return True
 
     async def start(self) -> None:
         """Start the engine loop."""
@@ -274,7 +313,10 @@ class EngineCore:
                         # making the server unresponsive to all HTTP requests.
                         await asyncio.sleep(0)
                 else:
-                    # No work, yield control
+                    # No work, yield control. While here, periodically reap
+                    # the Metal cache so wired pages don't drift up forever
+                    # on long-idle servers (mlx-lm#883/#1015).
+                    self._maybe_reap_idle_cache(time.monotonic())
                     await asyncio.sleep(step_interval)
 
             except asyncio.CancelledError:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -384,12 +384,20 @@ class MLLMBatchGenerator:
         if MLLMBatchGenerator._stream is None:
             MLLMBatchGenerator._stream = mx.new_stream(mx.default_device())
 
-        # Memory management
+        # Memory management. Coordinated wired-limit: when multiple servers
+        # share a host (e.g. arena fronting 9 vllm-mlx processes), each
+        # raising the limit to 75% of physical RAM independently sums to a
+        # request the kernel can't satisfy, leading to wired-page contention
+        # and the cascading hang in mlx-lm#883/#1015. Divide by an env-
+        # supplied sibling count so the per-process budget stays sane.
+        import os
         self._old_wired_limit = None
         if mx.metal.is_available():
-            self._old_wired_limit = mx.set_wired_limit(
-                mx.device_info()["max_recommended_working_set_size"]
+            num_servers = max(1, int(os.getenv("VLLM_MLX_NUM_SERVERS", "1")))
+            target = int(
+                mx.device_info()["max_recommended_working_set_size"] / num_servers
             )
+            self._old_wired_limit = mx.set_wired_limit(target)
 
     def close(self) -> None:
         """Release resources and reset wired limit."""


### PR DESCRIPTION
## Summary

Three changes targeting the wired-page accumulation cascade documented in mlx-lm/issues/883 and /1015. Reproduced in production: 3 of 6 sibling vllm-mlx text LLMs hung simultaneously after ~12h of uptime, all with VSZ ≈ 700 GB and only ~16 GB RSS resident, while \`vm_stat\` showed 30M wired pages (~464 GB out of 512 GB physical, ~264 MB free). Killing and restarting released 441 GB of wired pages instantly.

### Change 1: \`engine_core.py\` idle-branch cache reap

The active branch of the engine loop already calls \`mx.clear_cache()\` at \`:229\` and \`:269\`. The idle branch (no requests scheduled) was just \`await asyncio.sleep(step_interval)\` — so wired pages held during the prior burst stayed pinned forever. Now reaps every \`IDLE_REAP_INTERVAL_S\` seconds (default 30, env: \`VLLM_MLX_IDLE_REAP_INTERVAL_S\`).

### Change 2: \`engine/batched.py\` env-configurable caps

- \`VLLM_MLX_NUM_SERVERS\`: divides \`set_memory_limit\` so N sibling servers don't each request 90% of physical RAM. Default 1 preserves current behavior.
- \`VLLM_MLX_CACHE_LIMIT_BYTES\`: makes the existing 32 GB cache cap configurable. Default unchanged.

### Change 3: \`mllm_batch_generator.py\` coordinated \`set_wired_limit\`

Same \`VLLM_MLX_NUM_SERVERS\` divisor applied to the multimodal path's \`mx.set_wired_limit\`. Awni's specific recommendation in mlx-lm#883 was that wiring 75% per server with no coordination is the proximate cause of the kernel-level cascade.

## Defaults preserve current behavior

- \`VLLM_MLX_NUM_SERVERS=1\` (no division)
- \`VLLM_MLX_CACHE_LIMIT_BYTES=34359738368\` (32 GB, same as hardcoded value before)
- \`VLLM_MLX_IDLE_REAP_INTERVAL_S=30\`

Operators running multi-server setups (e.g. arena fronting 9 vllm-mlx processes) set \`VLLM_MLX_NUM_SERVERS\` on the spawn command to scale the per-process budget.

## Test plan

- [x] 6 unit tests in \`tests/test_engine_core_idle_reap.py\` covering the reap predicate (fires after interval, skips within interval, handles \`mx.clear_cache\` exception, env-configurable, no-op when Metal unavailable).
- [x] Adjacent memory tests still pass: \`test_memory_stability.py\` (16/16), \`test_engine_core_stream_safety.py\` (1/1).
- [ ] Manual: run with \`VLLM_MLX_IDLE_REAP_INTERVAL_S=5\` and idle the engine; verify clear_cache fires every ~5s in logs and Metal cache stat drops accordingly.

## References

- mlx-lm/issues/883 — kernel panic from unbounded wired memory; Awni acknowledged "the wired limit being too high"
- mlx-lm/issues/1015 — production workaround = periodic process recycling + clear_cache + cache_limit caps
- mlx-explore/mlx/issues/2668 — canonical "memory not released" issue
- Companion PR: hank-ai/hank-llm-arena#76 (operational mitigation: 6h periodic process recycle while these framework-level fixes deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)