### PR TITLE
feat(server): always-responsive /health from a separate thread

### DIFF
--- a/tests/test_fast_health_thread.py
+++ b/tests/test_fast_health_thread.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the always-responsive health thread.
+
+Production bug: the existing async /health endpoint sits on the same
+uvicorn event loop as /v1/messages. When inference holds the loop
+during a long prefill, /health stops responding within arena's 5s probe
+budget, so the server appears "offline" mid-request even though it is
+actively generating. This breaks the Tauri filter and any external
+liveness monitor.
+
+Fix: spawn a stdlib threading HTTP server on a separate port. It runs
+in its own thread, so it does not depend on the event loop. MLX kernels
+release the GIL during Metal compute, so even when the main event loop
+is blocked Python-side, the health thread can acquire the GIL and serve
+the response in microseconds.
+
+These tests verify:
+- The health server's request handler produces the expected JSON shape
+  (must remain compatible with arena's reconciler shape detection,
+  which keys on `model_name` for vllm-mlx).
+- The handler is purely synchronous and does NOT depend on the engine
+  having any particular state — just the model name string.
+- It returns 404 for paths other than /health (so we don't accidentally
+  expose anything else).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from http.server import BaseHTTPRequestHandler
+
+
+def _make_response(handler_cls, model_name: str, path: str = "/health"):
+    """Drive the handler through a fake socket so we can assert the
+    response without actually opening a port."""
+    class _StubServer:
+        pass
+    server = _StubServer()
+
+    class _StubRequest:
+        def __init__(self, raw: bytes):
+            self._buf = io.BytesIO(raw)
+        def makefile(self, mode, *a, **kw):
+            return self._buf
+        def sendall(self, *a, **kw):
+            pass
+
+    raw = f"GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
+    request = _StubRequest(raw)
+
+    out = io.BytesIO()
+
+    class _Handler(handler_cls):
+        # Override __init__ to capture state without binding sockets
+        def __init__(self, request, client_address, server):  # noqa: D401
+            self.rfile = request.makefile("rb")
+            self.wfile = out
+            self.client_address = ("127.0.0.1", 0)
+            self.server = server
+            self.command = ""
+            self.path = ""
+            self.request_version = "HTTP/1.1"
+            self.headers = None
+            self.raw_requestline = b""
+            self.close_connection = True
+            self._handle_one()
+
+        def _handle_one(self):
+            self.raw_requestline = self.rfile.readline()
+            if not self.parse_request():
+                return
+            mname = "do_" + self.command
+            if hasattr(self, mname):
+                getattr(self, mname)()
+
+        def log_message(self, *_args, **_kwargs):
+            pass
+
+    # Inject the model name (handler reads it from a class attribute).
+    handler_cls._MODEL_NAME = model_name
+    _Handler(request, ("127.0.0.1", 0), server)
+    return out.getvalue()
+
+
+def test_health_endpoint_returns_200_and_model_name():
+    from vllm_mlx.fast_health import HealthHandler
+
+    raw = _make_response(HealthHandler, model_name="mlx-community/test-model")
+    text = raw.decode("latin-1")
+    # Status line
+    assert text.startswith(("HTTP/1.0 200", "HTTP/1.1 200")), text[:80]
+    # Body must be parseable JSON with model_name (arena's reconciler
+    # contract — see registry_reconciler.py:_probe_one).
+    body_start = text.index("\r\n\r\n") + 4
+    body = json.loads(text[body_start:])
+    assert body["model_name"] == "mlx-community/test-model"
+    assert body.get("status") in ("healthy", "ok")
+
+
+def test_health_endpoint_uses_stable_shape_for_arena_detection():
+    """Arena keys vllm-mlx detection on the presence of `model_name` and
+    keys mlx-vlm detection on `loaded_model`. The health thread must
+    NOT include `loaded_model` so arena correctly classifies as vllm-mlx."""
+    from vllm_mlx.fast_health import HealthHandler
+
+    raw = _make_response(HealthHandler, model_name="x")
+    body = json.loads(raw.decode("latin-1").split("\r\n\r\n", 1)[1])
+    assert "model_name" in body, "arena needs model_name for vllm-mlx detection"
+    assert "loaded_model" not in body, (
+        "must NOT have loaded_model — that's the mlx-vlm signal"
+    )
+
+
+def test_other_paths_return_404():
+    from vllm_mlx.fast_health import HealthHandler
+
+    for path in ("/", "/v1/models", "/healthz", "/health.json", "/admin"):
+        raw = _make_response(HealthHandler, model_name="x", path=path)
+        text = raw.decode("latin-1")
+        assert text.startswith(("HTTP/1.0 404", "HTTP/1.1 404")), f"path {path}: {text[:80]}"
+
+
+def test_handler_does_not_couple_to_engine_or_event_loop():
+    """The whole point of the fast-health thread is that it does not
+    depend on the engine state — so it can serve while the engine's
+    event loop is blocked. The handler must NOT import or call into
+    vllm_mlx.engine, vllm_mlx.scheduler, or anything async."""
+    import inspect
+    from vllm_mlx.fast_health import HealthHandler
+
+    src = inspect.getsource(HealthHandler)
+    forbidden = ("get_stats", "_engine", "_scheduler", "asyncio", "await")
+    for word in forbidden:
+        assert word not in src, (
+            f"handler must not reference '{word}' — would couple it to the "
+            f"event loop / engine state and defeat the whole purpose"
+        )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -215,6 +215,30 @@ def serve_command(args):
         compile=args.compile,
     )
 
+    # Spawn the always-responsive health thread on a separate port so
+    # external probers (arena, monitoring) get an answer even when the
+    # main async /health is starved by an inference step that's holding
+    # the uvicorn event loop. See vllm_mlx/fast_health.py.
+    _health_port_arg = getattr(args, "health_port", None)
+    if _health_port_arg is None:
+        _health_port = args.port + 100
+    elif _health_port_arg == 0:
+        _health_port = None  # explicitly disabled
+    else:
+        _health_port = _health_port_arg
+    if _health_port is not None:
+        from .fast_health import start_health_server
+        served_name = (
+            args.served_model_name
+            if getattr(args, "served_model_name", None)
+            else args.model
+        )
+        start_health_server(
+            model_name=served_name,
+            port=_health_port,
+            host=args.host,
+        )
+
     # Start server
     print(f"Starting server at http://{args.host}:{args.port}")
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")
@@ -776,6 +800,18 @@ Examples:
         "--host", type=str, default="0.0.0.0", help="Host to bind"
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    serve_parser.add_argument(
+        "--health-port",
+        type=int,
+        default=None,
+        help=(
+            "Port for the always-responsive /health endpoint, served from a "
+            "separate thread that doesn't share the inference event loop. "
+            "Default: --port + 100. Set to 0 to disable. External liveness "
+            "probers (arena, monitoring) should prefer this port — the "
+            "default async /health blocks during long prefills."
+        ),
+    )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=256, help="Max concurrent sequences"
     )

--- a/vllm_mlx/fast_health.py
+++ b/vllm_mlx/fast_health.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Always-responsive health server.
+
+Runs in its own thread on a separate port so it does not depend on
+uvicorn's event loop. The default async /health endpoint is co-resident
+with /v1/messages on the asyncio loop; when an inference step blocks
+the loop (which can take seconds for a long prefill), /health stops
+responding within typical 5s prober budgets, and external monitors
+incorrectly conclude the model is offline.
+
+This thread is purely synchronous, holds GIL only for microseconds per
+request, and serves a static JSON envelope (just the model name). MLX
+kernels release the GIL during their Metal compute, so this thread
+gets enough scheduling windows to satisfy probes even under heavy
+inference load.
+
+Usage from server.py:
+
+    from vllm_mlx.fast_health import start_health_server
+    start_health_server(model_name=..., port=8100)
+
+The handler does NOT touch the engine, scheduler, or any async state.
+That decoupling is the whole point — keep it that way. The unit test
+`test_handler_does_not_couple_to_engine_or_event_loop` enforces this.
+
+Response shape matches arena's reconciler contract: a JSON dict with
+`model_name` (vllm-mlx signal). NOT `loaded_model` (that is the
+mlx-vlm signal — different shim path).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+logger = logging.getLogger(__name__)
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """Static health responder. Returns 200 with a JSON envelope on
+    /health, 404 on anything else.
+
+    Reads the served model name from the class attribute `_MODEL_NAME`
+    (set by `start_health_server`). Pure synchronous, no engine or loop
+    coupling — see the test that pins this contract.
+    """
+
+    _MODEL_NAME: str = ""
+
+    def do_GET(self):  # noqa: N802 — stdlib mandates this name
+        if self.path != "/health":
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            return
+        body = json.dumps({
+            "status": "healthy",
+            "model_name": type(self)._MODEL_NAME,
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args, **_kwargs):
+        # Stay quiet — these probes fire 6/min per arena prober and
+        # would otherwise drown the model log.
+        pass
+
+
+def start_health_server(*, model_name: str, port: int, host: str = "0.0.0.0") -> None:
+    """Spawn the health-server thread. Daemon, so it dies with the
+    parent process — no shutdown coordination needed.
+
+    Idempotent only at the caller level; calling twice will fail to
+    bind the port the second time.
+    """
+    HealthHandler._MODEL_NAME = model_name
+
+    def _serve():
+        try:
+            server = ThreadingHTTPServer((host, port), HealthHandler)
+        except OSError as e:
+            logger.warning(
+                "fast-health server could not bind %s:%d: %s — "
+                "external probers will fall back to the async /health",
+                host, port, e,
+            )
+            return
+        logger.info(
+            "fast-health server listening on %s:%d (model=%s)",
+            host, port, model_name,
+        )
+        server.serve_forever()
+
+    t = threading.Thread(target=_serve, name="fast-health", daemon=True)
+    t.start()


### PR DESCRIPTION
## Summary

The existing async \`/health\` endpoint shares the uvicorn event loop with \`/v1/messages\`. When inference holds the loop during a long prefill, \`/health\` stops responding within typical 5s prober budgets — external liveness monitors incorrectly conclude the server is offline mid-request.

Fix: spawn a **stdlib threading HTTP server on a separate port** (default \`--port + 100\`, configurable via \`--health-port\`, set to 0 to disable). The thread runs purely synchronous Python that doesn't touch the engine or async state. MLX kernels release the GIL during Metal compute, so the health thread serves responses in microseconds even under heavy inference load.

## Test plan

- [x] 4 unit tests pin the response shape (compatible with arena's reconciler model_name signal, NOT loaded_model which is mlx-vlm), 404 for non-/health paths, and a contract test that asserts the handler doesn't reference engine/scheduler/asyncio
- [x] Live smoke test: \`start_health_server(model_name='test-model', port=19998)\` then \`curl /health\` returns the expected JSON in 200/sub-millisecond
- [ ] Manual verification with arena's companion PR: during a 35s prefill, \`curl /health\` on port+100 keeps responding

## Companion

\`hank-ai/hank-llm-arena\` reconciler now probes port + ARENA_FAST_HEALTH_OFFSET (default 100) first, falls back to base port for back-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)